### PR TITLE
feat: P13 polish — schema toggle, dep array fix, agentId auto-suggest

### DIFF
--- a/src/app/(demo)/venues/[slug]/page.tsx
+++ b/src/app/(demo)/venues/[slug]/page.tsx
@@ -79,7 +79,7 @@ export default function VenuePage({ params }: VenuePageProps) {
          addVenue(venue)
        })
     }
-  }, [slug, venues, authMap, getAuthForVenue]);
+  }, [slug, venues, authMap, getAuthForVenue, addVenue]);
 
     useEffect(() => {
        const fetchMCP = async () => {

--- a/src/components/AddNewAgent.tsx
+++ b/src/components/AddNewAgent.tsx
@@ -35,6 +35,9 @@ interface AddNewAgentProps {
   onCreated?: () => void;
 }
 
+const slugify = (name: string) =>
+  name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "").replace(/-+/g, "-").replace(/^-|-$/g, "");
+
 export function AddNewAgent({
   trigger,
   initialAgentName = "",
@@ -43,6 +46,8 @@ export function AddNewAgent({
   onCreated,
 }: AddNewAgentProps = {}) {
   const [agentName, setAgentName] = useState(initialAgentName);
+  const [agentId, setAgentId] = useState("");
+  const [agentIdEdited, setAgentIdEdited] = useState(false);
   const [llmProvider, setLlmProvider] = useState(initialProvider);
   const [systemPrompt, setSystemPrompt] = useState(initialSystemPrompt);
   const [initialCommand, setInitialCommand] = useState("");
@@ -50,11 +55,14 @@ export function AddNewAgent({
   const [open, setOpen] = useState(false);
   const [availableKeys, setAvailableKeys] = useState<string[]>([]);
 
+
   const venue = useAuthenticatedVenue();
 
   useEffect(() => {
     if (!open) return;
     setAgentName(initialAgentName);
+    setAgentId(slugify(initialAgentName));
+    setAgentIdEdited(false);
     setSystemPrompt(initialSystemPrompt);
     setLlmProvider(initialProvider);
     setInitialCommand("");
@@ -81,7 +89,7 @@ export function AddNewAgent({
     try {
       const provider = LLM_PROVIDERS[llmProvider];
       const result = await venue.agents.create({
-        agentId: agentName,
+        agentId: agentId.trim() || slugify(agentName),
         config: {
           operation: "v/ops/llmagent/chat",
           llmOperation: provider.operation,
@@ -97,6 +105,8 @@ export function AddNewAgent({
         description: `Agent "${result.agentId}" is now ${result.status}`,
       });
       setAgentName("");
+      setAgentId("");
+      setAgentIdEdited(false);
       setSystemPrompt("");
       setInitialCommand("");
       setOpen(false);
@@ -135,8 +145,30 @@ export function AddNewAgent({
               data-testid="agent-name"
               placeholder="e.g., Customer Support Agent"
               value={agentName}
-              onChange={(e) => setAgentName(e.target.value)}
+              onChange={(e) => {
+                setAgentName(e.target.value);
+                if (!agentIdEdited) setAgentId(slugify(e.target.value));
+              }}
             />
+          </div>
+
+          {/* Agent ID */}
+          <div className="space-y-2 w-full">
+            <Label htmlFor="agent-id" className="w-32 text-sm">
+              Agent ID:
+            </Label>
+            <Input
+              id="agent-id"
+              placeholder="e.g., customer-support-agent"
+              value={agentId}
+              onChange={(e) => {
+                setAgentId(e.target.value);
+                setAgentIdEdited(true);
+              }}
+            />
+            <p className="text-xs text-muted-foreground">
+              Unique identifier — auto-suggested from name. Edit to override.
+            </p>
           </div>
 
           {/* LLM Provider */}

--- a/src/components/OperationViewer.tsx
+++ b/src/components/OperationViewer.tsx
@@ -37,6 +37,7 @@ export const OperationViewer = (props: any) => {
   const [rawInput, setRawInput] = useState<Record<string, string>>({}); // raw input content before parsing per field name
   const [typeMap, setTypeMap] = useState<Record<string, string>>({}); // user-specified types of the values to be passed to the operation, affects parsing
   const [assetNotFound, setAssetNotFound] = useState(false);
+  const [showSchema, setShowSchema] = useState(false);
   const getAuthForVenue = useAuthStore((x) => x.getAuthForVenue);
   const authMap = useAuthStore((x) => x.authMap);
 
@@ -563,7 +564,16 @@ export const OperationViewer = (props: any) => {
         {!assetNotFound && asset && <MetadataViewer asset={asset} />}
         {!assetNotFound && asset?.metadata?.operation && (
           <>
-            
+            <div className="w-full flex justify-end mb-1">
+              <Button variant="outline" size="sm" onClick={() => setShowSchema(v => !v)}>
+                {showSchema ? "Hide Schema" : "View Schema"}
+              </Button>
+            </div>
+            {showSchema && (
+              <pre className="w-full text-xs bg-muted rounded-md p-4 overflow-x-auto whitespace-pre-wrap break-all mb-2">
+                {JSON.stringify({ input: asset.metadata.operation.input, output: asset.metadata.operation.output }, null, 2)}
+              </pre>
+            )}
             {renderInputFields(asset?.metadata?.operation?.input)}
             {asset?.metadata?.operation?.steps && <DiagramViewer metadata={asset.metadata}></DiagramViewer>}
           </>


### PR DESCRIPTION
## Summary

Three small P13 polish items:

- **OperationViewer** — adds a "View Schema" / "Hide Schema" toggle above the input form. When expanded, renders the raw JSON Schema for the operation's `input` and `output` as a formatted pre block.
- **VenuePage** — adds the missing `addVenue` to the first `useEffect` dependency array (React hooks lint warning).
- **AddNewAgent** — auto-suggests a slugified `agentId` as the user types the agent name (e.g. "Customer Support Agent" → `customer-support-agent`). The ID field is editable to override, and auto-sync stops once the user manually edits it. Resets on dialog open/close.

## Test plan

- [ ] Open an operation — confirm "View Schema" button appears; click toggles the JSON Schema block on/off
- [ ] Open Add Agent dialog — type a name, confirm Agent ID field auto-fills with a slug; edit the ID manually, confirm it stops following the name
- [ ] No lint warnings on VenuePage useEffect in editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)