### PR TITLE
Guard persisted stores against an unusable localStorage

### DIFF
--- a/__tests__/persist-storage.test.ts
+++ b/__tests__/persist-storage.test.ts
@@ -1,0 +1,88 @@
+// Zustand's `createJSONStorage(() => localStorage)` only falls back to "no
+// persistence" when reading the global *throws*. Node >= 22 defines a
+// `localStorage` global that is a plain object with no methods unless the
+// process was started with a valid `--localstorage-file` path, so the read
+// succeeds and zustand hands back a wrapper over a non-functional stub. The
+// first persisted write then throws "storage.setItem is not a function" —
+// during SSR this surfaced as an unhandled rejection on every render.
+//
+// The same shape occurs in a browser whose storage is unavailable (Safari
+// private browsing, storage disabled by policy), so the guard probes for the
+// API rather than for `window`.
+
+const methodlessStorage = {} as Storage;
+
+const workingStorage = (): Storage => {
+  const entries = new Map<string, string>();
+  return {
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => void entries.set(key, value),
+    removeItem: (key: string) => void entries.delete(key),
+  } as unknown as Storage;
+};
+
+const withLocalStorage = (value: Storage | undefined, run: () => void) => {
+  const original = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+  Object.defineProperty(globalThis, 'localStorage', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+  try {
+    run();
+  } finally {
+    if (original) Object.defineProperty(globalThis, 'localStorage', original);
+    else delete (globalThis as { localStorage?: Storage }).localStorage;
+  }
+};
+
+describe('browserStorage', () => {
+  it('falls back to a no-op when localStorage exists but has no methods', () => {
+    withLocalStorage(methodlessStorage, () => {
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { browserStorage } = require('@/lib/persist-storage');
+        const storage = browserStorage();
+
+        expect(() => storage.setItem('venues', '{}')).not.toThrow();
+        expect(() => storage.removeItem('venues')).not.toThrow();
+        expect(storage.getItem('venues')).toBeNull();
+      });
+    });
+  });
+
+  it('falls back to a no-op when there is no localStorage global at all', () => {
+    withLocalStorage(undefined, () => {
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { browserStorage } = require('@/lib/persist-storage');
+        expect(() => browserStorage().setItem('venues', '{}')).not.toThrow();
+      });
+    });
+  });
+
+  it('uses the real localStorage when it is usable, so persistence still works', () => {
+    const real = workingStorage();
+    withLocalStorage(real, () => {
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { browserStorage } = require('@/lib/persist-storage');
+        browserStorage().setItem('venues', '{"state":{}}');
+        expect(real.getItem('venues')).toBe('{"state":{}}');
+      });
+    });
+  });
+});
+
+describe('persisted stores where localStorage is unusable', () => {
+  it('does not throw when a store is written', () => {
+    withLocalStorage(methodlessStorage, () => {
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { useSidebar } = require('@/hooks/use-sidebar');
+        expect(() => useSidebar.getState().setIsOpen(false)).not.toThrow();
+        expect(useSidebar.getState().isOpen).toBe(false);
+      });
+    });
+  });
+});

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -3,6 +3,7 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { useVenues } from "@/hooks/use-venues";
+import { browserStorage } from "@/lib/persist-storage";
 
 export type BearerVenueAuth = {
   type: "bearer";
@@ -175,7 +176,7 @@ export const useAuthStore = create(
     }),
     {
       name: "venue-auth",
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(browserStorage),
       merge: (persisted, current) => {
         const old = persisted as {
           authMap?: Record<string, VenueAuth>;

--- a/src/hooks/use-sidebar.ts
+++ b/src/hooks/use-sidebar.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { produce } from "immer";
+import { browserStorage } from "@/lib/persist-storage";
 
 type SidebarSettings = { disabled: boolean; isHoverOpen: boolean };
 type SidebarStore = {
@@ -43,7 +44,7 @@ export const useSidebar = create(
     }),
     {
       name: "sidebar",
-      storage: createJSONStorage(() => localStorage)
+      storage: createJSONStorage(browserStorage)
     }
   )
 );

--- a/src/hooks/use-venues.ts
+++ b/src/hooks/use-venues.ts
@@ -5,6 +5,7 @@ import { persist, createJSONStorage } from "zustand/middleware";
 import { Venue } from "@covia/covia-sdk";
 import type { Auth } from "@covia/covia-sdk";
 import { reportVenueHealth } from "@/hooks/use-venue-health";
+import { browserStorage } from "@/lib/persist-storage";
 
 export type VenueDescriptor = {
   venueId: string;
@@ -112,7 +113,7 @@ export function connectDefaultVenues(): Promise<Venue[]> {
 
 function legacySelectedVenueId(): string | null {
   try {
-    const raw = localStorage.getItem("current-venue");
+    const raw = browserStorage().getItem("current-venue");
     const parsed = raw ? JSON.parse(raw) : null;
     return parsed?.state?.currentVenue?.venueId ?? null;
   } catch {
@@ -158,7 +159,7 @@ export const useVenues = create(
     }),
     {
       name: "venues",
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(browserStorage),
       merge: (persisted, current) => {
         const saved = persisted as Partial<VenuesStore>;
         const venues = (saved.venues ?? [])

--- a/src/lib/persist-storage.ts
+++ b/src/lib/persist-storage.ts
@@ -1,0 +1,40 @@
+// Storage backend for zustand's `persist`, and for any other direct
+// `localStorage` read. Zustand only falls back to "no persistence" when
+// *reading* the `localStorage` global throws, which is not enough in two real
+// cases: Node >= 22 defines `localStorage` as an object with no methods unless
+// started with a valid `--localstorage-file` path (so every persisted write
+// during SSR threw "storage.setItem is not a function"), and browsers expose an
+// unusable object under private browsing or storage policy. Probe for the API
+// itself rather than for the global.
+//
+// Structurally compatible with zustand's `StateStorage`, but synchronous, so
+// callers reading a key directly get a `string | null` rather than a union with
+// a promise.
+
+export type SyncStorage = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+};
+
+const noopStorage: SyncStorage = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+};
+
+const isUsable = (storage: Storage | undefined): storage is Storage =>
+  typeof storage?.getItem === "function" &&
+  typeof storage?.setItem === "function" &&
+  typeof storage?.removeItem === "function";
+
+export function browserStorage(): SyncStorage {
+  // Reading the global at all emits a Node warning, so bail out before that.
+  if (typeof window === "undefined") return noopStorage;
+  try {
+    return isUsable(window.localStorage) ? window.localStorage : noopStorage;
+  } catch {
+    // Reading the property throws outright when storage is blocked by policy.
+    return noopStorage;
+  }
+}


### PR DESCRIPTION
## Problem

Zustand's `createJSONStorage(() => localStorage)` only falls back to "no persistence" when *reading* the `localStorage` global throws. Node >= 22 defines `localStorage` as an object with **no methods** unless the process is started with a valid `--localstorage-file` path, so the read succeeds and zustand hands back a wrapper over a non-functional stub. The first persisted write on the server then throws:

```
TypeError: storage.setItem is not a function
```

On `main` this fired as an unhandled rejection on every render of `/`, because `use-venues` called `setState` from module scope. On `develop` that module-scope call is gone, so it does not currently fire — but the hazard is latent for any store written during SSR.

Reproduced in isolation on Node 25.8.1: `typeof localStorage` is `object` while `typeof localStorage.setItem` is `undefined`, and a store write throws synchronously.

## Fix

Route the three persisted stores (`use-venues`, `use-auth`, `use-sidebar`) through a shared `browserStorage` helper that returns a no-op unless the storage API is actually present. It probes for the methods rather than for `window`, so it also covers browsers that withhold storage under private browsing or policy, and it short-circuits before touching the global on the server so Node no longer emits its `--localstorage-file` warning.

The direct `current-venue` read in `use-venues` goes through the same helper, so nothing reads the global unguarded any more.

## Tests

`__tests__/persist-storage.test.ts` reproduces the exact failure before the fix — a `localStorage` that exists but has no methods — and covers the no-global case plus the case where real storage is present, so persistence is not silently disabled.

## Verification

- `pnpm test` — 345 tests across 57 suites pass
- `pnpm lint` — clean
- `npx tsc --noEmit` — no new errors
- Dev server log clean: no `storage.setItem` error and no Node localStorage warning
- Persistence confirmed in the browser: deleting the `venues` key and reloading rewrites it with both venues

## Note

`develop` currently fails `pnpm build` on two pre-existing TypeScript errors in `src/components/DidDisplay.tsx` (`value` narrows to `never`). These reproduce on a clean checkout of `origin/develop` with this branch's changes stashed, so they are unrelated to this PR, but they will block CI until fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)