### PR TITLE
Two demos on a shared kit: Adaptive Risk (a gate that refuses) and Governed Escalation (a human who decides)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,10 @@ next-env.d.ts
 .vercel
 .project
 /.settings/
+
+# Internal planning/decision records — must never reach this PUBLIC repo.
+# Candid rationale (venue gaps, trade-offs, what was rejected and why) is
+# invaluable internally and dangerous once exposed. Canonical home for this
+# material is the private covia-demos-program/planning/<slug>/.
+DECISIONS.md
+**/DECISIONS.md

--- a/__tests__/AdaptiveRiskDemo.test.tsx
+++ b/__tests__/AdaptiveRiskDemo.test.tsx
@@ -14,6 +14,10 @@ jest.mock('@/hooks/use-authenticated-venue', () => ({
 }));
 jest.mock('@/hooks/use-auth', () => ({
   useIsAuthenticated: () => mockAuthenticated,
+  // Beat 5 signs the curl's identity token with the device key; the shell
+  // tests only need the selector to resolve.
+  useAuthStore: (selector: (state: unknown) => unknown) =>
+    selector({ authMap: {} }),
 }));
 
 import { AdaptiveRiskDemo } from '@/components/adaptive-risk/AdaptiveRiskDemo';

--- a/__tests__/AdaptiveRiskDemo.test.tsx
+++ b/__tests__/AdaptiveRiskDemo.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Keep a stable venue object across renders (same pattern as
+// JobLifecycleDemo.test.tsx) so venue-keyed effects don't refire.
+const mockVenueHolder: { venue: unknown } = {
+  venue: { venueId: 'test-venue', baseUrl: 'http://venue.test' },
+};
+let mockAuthenticated = true;
+
+jest.mock('@/hooks/use-authenticated-venue', () => ({
+  useAuthenticatedVenue: () => mockVenueHolder.venue,
+}));
+jest.mock('@/hooks/use-auth', () => ({
+  useIsAuthenticated: () => mockAuthenticated,
+}));
+
+import { AdaptiveRiskDemo } from '@/components/adaptive-risk/AdaptiveRiskDemo';
+import { ADAPTIVE_RISK_BEATS } from '@/components/adaptive-risk/story';
+import { DEMOS, demoBySlug } from '@/lib/demos';
+
+beforeEach(() => {
+  mockVenueHolder.venue = { venueId: 'test-venue', baseUrl: 'http://venue.test' };
+  mockAuthenticated = true;
+});
+
+describe('demo registry', () => {
+  it('lists both demos with unique slugs', () => {
+    const slugs = DEMOS.map((d) => d.slug);
+    expect(slugs).toContain('sdk-job-lifecycle');
+    expect(slugs).toContain('adaptive-risk');
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('resolves a demo by slug and misses unknown slugs', () => {
+    expect(demoBySlug('adaptive-risk')?.title.highlight).toBe('Risk');
+    expect(demoBySlug('nope')).toBeUndefined();
+  });
+});
+
+describe('AdaptiveRiskDemo shell', () => {
+  it('always renders the honesty panel with the synthetic-data statement', () => {
+    render(<AdaptiveRiskDemo />);
+    const honesty = screen.getByTestId('ar-honesty');
+    expect(honesty).toHaveTextContent(/all data is synthetic/i);
+    expect(honesty).toHaveTextContent(/fixture swap/i);
+    expect(honesty).toHaveTextContent(/not trained scorecards/i);
+    expect(honesty).toHaveTextContent(/unrestricted/);
+  });
+
+  it('renders all five beats from the story data', () => {
+    render(<AdaptiveRiskDemo />);
+    for (const beat of ADAPTIVE_RISK_BEATS) {
+      expect(screen.getByTestId(`ar-beat-${beat.id}`)).toHaveTextContent(beat.title);
+    }
+    expect(ADAPTIVE_RISK_BEATS).toHaveLength(5);
+  });
+
+  it('asks for a venue when none is selected', () => {
+    mockVenueHolder.venue = null;
+    render(<AdaptiveRiskDemo />);
+    expect(screen.getByTestId('ar-no-venue')).toBeInTheDocument();
+  });
+
+  it('asks for sign-in when unauthenticated', () => {
+    mockAuthenticated = false;
+    render(<AdaptiveRiskDemo />);
+    expect(screen.getByTestId('ar-no-auth')).toBeInTheDocument();
+  });
+
+  it('never uses the word "replay" in narration (JOBS.md: reconstruct, never re-execute)', () => {
+    expect(JSON.stringify(ADAPTIVE_RISK_BEATS)).not.toMatch(/replay/i);
+  });
+});

--- a/__tests__/adaptive-risk-beats.test.tsx
+++ b/__tests__/adaptive-risk-beats.test.tsx
@@ -13,6 +13,7 @@ import {
   runAssessorBeat,
   readLedger,
   readDecisions,
+  findOpenAsk,
   AGENT_REQUEST_OP,
 } from '@/components/adaptive-risk/beats';
 import { BeatCard } from '@/components/adaptive-risk/BeatCard';
@@ -258,5 +259,32 @@ describe('RefusalPanel', () => {
       <RefusalPanel state={{ jobId: 'j', status: 'COMPLETE', error: null, output: { ok: true } }} />,
     );
     expect(screen.getByTestId('ar-refusal-none')).toHaveTextContent(/did not refuse/i);
+  });
+});
+
+describe('findOpenAsk (beat 4)', () => {
+  it('prefers the newest open ask, so a stale one never captures the deep link', async () => {
+    const records: Record<string, unknown> = {
+      'h/001': { status: 'answered', title: 'Raise ... S$800 ...' },
+      'h/002': { status: 'open', title: 'Raise ... S$800 ...' },
+      'h/003': { status: 'open', title: 'Raise ... S$800 ...' },
+    };
+    const venue = {
+      workspace: {
+        list: jest.fn(async () => ({ exists: true, keys: ['001', '002', '003'] })),
+        read: jest.fn(async (path: string) => ({ exists: true, value: records[path] })),
+      },
+    } as never;
+    expect((await findOpenAsk(venue))?.id).toBe('003');
+  });
+
+  it('returns null when nothing is open rather than guessing', async () => {
+    const venue = {
+      workspace: {
+        list: jest.fn(async () => ({ exists: true, keys: ['001'] })),
+        read: jest.fn(async () => ({ exists: true, value: { status: 'answered', title: 'S$800' } })),
+      },
+    } as never;
+    expect(await findOpenAsk(venue)).toBeNull();
   });
 });

--- a/__tests__/adaptive-risk-beats.test.tsx
+++ b/__tests__/adaptive-risk-beats.test.tsx
@@ -14,6 +14,7 @@ import {
   readLedger,
   readDecisions,
   findOpenAsk,
+  extractGrantToken,
   AGENT_REQUEST_OP,
 } from '@/components/adaptive-risk/beats';
 import { BeatCard } from '@/components/adaptive-risk/BeatCard';
@@ -286,5 +287,27 @@ describe('findOpenAsk (beat 4)', () => {
       },
     } as never;
     expect(await findOpenAsk(venue)).toBeNull();
+  });
+});
+
+describe('extractGrantToken (beat 4)', () => {
+  const jwt =
+    'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJkaWQ6a2V5OnoxMjMiLCJleHAiOjk5OTk5fQ.c2lnbmF0dXJlLWJ5dGVzLWhlcmU';
+
+  it('finds a self-signed COG-19 token under tokens keyed by ask id', () => {
+    expect(
+      extractGrantToken({ outcome: 'answer', id: 'r1', tokens: { raise: jwt } }),
+    ).toBe(jwt);
+  });
+
+  it('finds a venue-minted COG-17 grant on token', () => {
+    expect(extractGrantToken({ outcome: 'answer', token: jwt })).toBe(jwt);
+  });
+
+  it('does not mistake ordinary strings for a token', () => {
+    expect(
+      extractGrantToken({ outcome: 'answer', comment: 'approved for 7 days', id: 'r1' }),
+    ).toBeNull();
+    expect(extractGrantToken(null)).toBeNull();
   });
 });

--- a/__tests__/adaptive-risk-beats.test.tsx
+++ b/__tests__/adaptive-risk-beats.test.tsx
@@ -15,6 +15,9 @@ import {
   readDecisions,
   findOpenAsk,
   extractGrantToken,
+  reconstructionCurl,
+  summariseRecord,
+  JOBS_MD_RULE,
   AGENT_REQUEST_OP,
 } from '@/components/adaptive-risk/beats';
 import { BeatCard } from '@/components/adaptive-risk/BeatCard';
@@ -309,5 +312,43 @@ describe('extractGrantToken (beat 4)', () => {
       extractGrantToken({ outcome: 'answer', comment: 'approved for 7 days', id: 'r1' }),
     ).toBeNull();
     expect(extractGrantToken(null)).toBeNull();
+  });
+});
+
+describe('reconstruction (beat 5)', () => {
+  it('builds a curl that carries identity, since job records are per-caller', () => {
+    const curl = reconstructionCurl('http://127.0.0.1:8080/', '0xJOB', 'tok123');
+    expect(curl).toContain('Authorization: Bearer tok123');
+    expect(curl).toContain('http://127.0.0.1:8080/api/v1/jobs/0xJOB');
+    expect(curl).not.toContain('//api'); // trailing slash normalised
+  });
+
+  it('falls back to a placeholder rather than a curl that would 404', () => {
+    const curl = reconstructionCurl('http://venue.test', '0xJOB', null);
+    expect(curl).toContain('$COVIA_TOKEN');
+  });
+
+  it('summarises the prev chain oldest-first', () => {
+    const record = {
+      status: 'COMPLETE',
+      caller: 'did:key:zOwner',
+      prev: { status: 'STARTED', prev: { status: 'PENDING' } },
+    };
+    const summary = summariseRecord(record);
+    expect(summary.states).toEqual(['PENDING', 'STARTED', 'COMPLETE']);
+    expect(summary.prevDepth).toBe(2);
+    expect(summary.caller).toBe('did:key:zOwner');
+    // actor appears only when the acting principal differs from the owner.
+    expect(summary.actor).toBeNull();
+  });
+
+  it('reports an actor when the acting principal differs from the owner', () => {
+    expect(summariseRecord({ status: 'FAILED', actor: 'did:key:zOwner:g:rk-assessor' }).actor)
+      .toBe('did:key:zOwner:g:rk-assessor');
+  });
+
+  it('never says "replay" — JOBS.md is reconstruct, never re-execute', () => {
+    expect(JOBS_MD_RULE).toMatch(/never re-executes/);
+    expect(JOBS_MD_RULE).not.toMatch(/replay/i);
   });
 });

--- a/__tests__/adaptive-risk-beats.test.tsx
+++ b/__tests__/adaptive-risk-beats.test.tsx
@@ -8,12 +8,23 @@ jest.mock('@/lib/operations-catalog', () => ({
   resolveOperationByAddress: (...args: unknown[]) => mockResolve(...args),
 }));
 
-import { runBeat1, readLedger, AGENT_REQUEST_OP } from '@/components/adaptive-risk/beats';
+import {
+  runBeat1,
+  runAssessorBeat,
+  readLedger,
+  readDecisions,
+  AGENT_REQUEST_OP,
+} from '@/components/adaptive-risk/beats';
 import { BeatCard } from '@/components/adaptive-risk/BeatCard';
 import { DEFAULT_ADDRESSES } from '@/components/adaptive-risk/fixtures';
 import { ADAPTIVE_RISK_BEATS } from '@/components/adaptive-risk/story';
 
 const beat1 = ADAPTIVE_RISK_BEATS[0];
+
+// The stub jobs below are structural stand-ins for Job; this keeps the cast
+// in one place rather than at every call site.
+type RunProp = React.ComponentProps<typeof BeatCard>['run'];
+const asRun = (fn: () => Promise<unknown>): RunProp => fn as unknown as RunProp;
 
 function finishedJob(overrides: Record<string, unknown> = {}) {
   return {
@@ -31,7 +42,7 @@ beforeEach(() => jest.clearAllMocks());
 
 describe('runBeat1', () => {
   it('dispatches the sentinel task through agent:request', async () => {
-    const invoke = jest.fn(async () => finishedJob());
+    const invoke = jest.fn(async (_input: unknown) => finishedJob());
     mockResolve.mockResolvedValue({ invoke });
     const venue = { venueId: 'v', baseUrl: 'http://venue.test' } as never;
 
@@ -46,6 +57,66 @@ describe('runBeat1', () => {
     expect(input.input.task).toContain('w/risk/applications');
     expect(input.input.task).toContain('sharedWith');
     expect(input.input.task).not.toMatch(/replay/i);
+  });
+});
+
+describe('runAssessorBeat', () => {
+  it('asks the assessor to issue exactly the given amount via the gated op', async () => {
+    const invoke = jest.fn(async (_input: unknown) => finishedJob());
+    mockResolve.mockResolvedValue({ invoke });
+    const info = jest.fn(async () => ({ status: 'SLEEPING' }));
+    const resume = jest.fn();
+    const venue = { agents: { info, resume } } as never;
+
+    await runAssessorBeat(venue, DEFAULT_ADDRESSES, 'APP-1071', 2500, 'dev-9903');
+
+    const input = invoke.mock.calls[0][0] as { agentId: string; input: { task: string } };
+    expect(input.agentId).toBe(DEFAULT_ADDRESSES.assessorAgent);
+    expect(input.input.task).toContain(DEFAULT_ADDRESSES.issueLimit);
+    expect(input.input.task).toContain('"amount": 2500');
+    expect(input.input.task).toContain('word for word');
+    // A healthy agent is not resumed.
+    expect(resume).not.toHaveBeenCalled();
+  });
+
+  it('clears a deliberate suspension before dispatching, and never swallows a failed resume', async () => {
+    const invoke = jest.fn(async (_input: unknown) => finishedJob());
+    mockResolve.mockResolvedValue({ invoke });
+    const info = jest.fn(async () => ({ status: 'SUSPENDED' }));
+
+    const resume = jest.fn();
+    await runAssessorBeat(
+      { agents: { info, resume } } as never,
+      DEFAULT_ADDRESSES, 'APP-1060', 500, 'dev-4411',
+    );
+    expect(resume).toHaveBeenCalledWith(DEFAULT_ADDRESSES.assessorAgent);
+
+    const failing = jest.fn(async () => { throw new Error('resume refused by venue'); });
+    await expect(
+      runAssessorBeat(
+        { agents: { info, resume: failing } } as never,
+        DEFAULT_ADDRESSES, 'APP-1060', 500, 'dev-4411',
+      ),
+    ).rejects.toThrow('resume refused by venue');
+  });
+});
+
+describe('readDecisions', () => {
+  it('reads the decision ledger job-free', async () => {
+    const read = jest.fn(async () => ({ exists: true, value: { applicant: 'APP-1060', status: 'approved' } }));
+    const list = jest.fn(async () => ({ exists: true, keys: ['APP-1060'] }));
+    const run = jest.fn();
+    const snapshot = await readDecisions({ workspace: { read, list }, operations: { run } } as never, DEFAULT_ADDRESSES);
+    expect(snapshot.applicants).toEqual(['APP-1060']);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('reports an empty ledger rather than inventing records', async () => {
+    const read = jest.fn();
+    const list = jest.fn(async () => ({ exists: false }));
+    const snapshot = await readDecisions({ workspace: { read, list } } as never, DEFAULT_ADDRESSES);
+    expect(snapshot.applicants).toEqual([]);
+    expect(read).not.toHaveBeenCalled();
   });
 });
 
@@ -90,7 +161,7 @@ describe('BeatCard', () => {
         venue={venue}
         enabled={false}
         disabledHint="Run setup above first"
-        run={jest.fn()}
+        run={asRun(async () => finishedJob())}
       />,
     );
     expect(screen.getByTestId('ar-run-silos')).toBeDisabled();
@@ -99,7 +170,7 @@ describe('BeatCard', () => {
 
   it('runs the beat and renders the job record with a Jobs deep link', async () => {
     const user = userEvent.setup();
-    const run = jest.fn(async () => finishedJob());
+    const run = asRun(async () => finishedJob());
     render(<BeatCard beat={beat1} venue={venue} enabled run={run} />);
 
     await user.click(screen.getByTestId('ar-run-silos'));
@@ -118,7 +189,7 @@ describe('BeatCard', () => {
     const user = userEvent.setup();
     const denial =
       'Capability denied by gate: gate w/ops/risk/limit-gate: Orchestration step 1 failed';
-    const run = jest.fn(async () =>
+    const run = asRun(async () =>
       finishedJob({
         isComplete: false,
         metadata: { status: 'FAILED', error: denial },

--- a/__tests__/adaptive-risk-beats.test.tsx
+++ b/__tests__/adaptive-risk-beats.test.tsx
@@ -352,3 +352,43 @@ describe('reconstruction (beat 5)', () => {
     expect(JOBS_MD_RULE).not.toMatch(/replay/i);
   });
 });
+
+describe('BeatCard parked jobs', () => {
+  const venue = { venueId: 'test-venue', baseUrl: 'http://venue.test' } as never;
+
+  it('settles on a job parked awaiting a human instead of polling forever', async () => {
+    const user = userEvent.setup();
+    const onSettled = jest.fn();
+    // INPUT_REQUIRED: not finished, but paused — the next move is the human's.
+    const parked = {
+      id: 'job-parked',
+      isFinished: false,
+      isPaused: true,
+      isComplete: false,
+      metadata: { status: 'INPUT_REQUIRED' },
+      output: null,
+      refresh: jest.fn(),
+    };
+    render(
+      <BeatCard
+        beat={beat1}
+        venue={venue}
+        enabled
+        run={asRun(async () => parked)}
+        onSettled={onSettled}
+      />,
+    );
+
+    await user.click(screen.getByTestId('ar-run-silos'));
+
+    await waitFor(() => expect(onSettled).toHaveBeenCalled());
+    expect(onSettled.mock.calls[0][0]).toMatchObject({
+      jobId: 'job-parked',
+      status: 'INPUT_REQUIRED',
+    });
+    // Never polled: a parked job is settled on arrival.
+    expect(parked.refresh).not.toHaveBeenCalled();
+    // And the beat is runnable again rather than stuck behind a spinner.
+    await waitFor(() => expect(screen.getByTestId('ar-run-silos')).toBeEnabled());
+  });
+});

--- a/__tests__/adaptive-risk-beats.test.tsx
+++ b/__tests__/adaptive-risk-beats.test.tsx
@@ -16,6 +16,7 @@ import {
   AGENT_REQUEST_OP,
 } from '@/components/adaptive-risk/beats';
 import { BeatCard } from '@/components/adaptive-risk/BeatCard';
+import { RefusalPanel, extractDenial } from '@/components/adaptive-risk/RefusalPanel';
 import { DEFAULT_ADDRESSES } from '@/components/adaptive-risk/fixtures';
 import { ADAPTIVE_RISK_BEATS } from '@/components/adaptive-risk/story';
 
@@ -203,5 +204,59 @@ describe('BeatCard', () => {
     await waitFor(() =>
       expect(screen.getByTestId('ar-error-silos')).toHaveTextContent(denial),
     );
+  });
+});
+
+describe('extractDenial (beat 3)', () => {
+  it("finds the venue's denial nested in an agent task envelope", () => {
+    const denial =
+      'Error: covia.exception.JobFailedException: Capability denied by gate: gate w/ops/risk/limit-gate: ... output schema violation: $.result.amount: value 2500.0 above maximum 500.0.';
+    const state = {
+      jobId: 'j1',
+      status: 'COMPLETE',
+      error: null,
+      output: { output: { error: denial, status: 'failed' }, status: 'COMPLETE' },
+    };
+    expect(extractDenial(state)).toBe(denial);
+  });
+
+  it('finds a denial on the job error when the invoke was denied directly', () => {
+    const denial = 'Capability denied by gate: gate w/ops/risk/limit-gate: nope';
+    expect(
+      extractDenial({ jobId: 'j', status: 'FAILED', error: denial, output: null }),
+    ).toBe(denial);
+  });
+
+  it('returns null rather than claiming a refusal that did not happen', () => {
+    expect(
+      extractDenial({
+        jobId: 'j',
+        status: 'COMPLETE',
+        error: null,
+        output: { output: { decision: { amount: 500 } } },
+      }),
+    ).toBeNull();
+    expect(extractDenial(null)).toBeNull();
+  });
+});
+
+describe('RefusalPanel', () => {
+  it('renders the denial verbatim and names the two-level outcome', () => {
+    const denial = 'Capability denied by gate: gate w/ops/risk/limit-gate: refused';
+    render(
+      <RefusalPanel
+        state={{ jobId: 'j', status: 'COMPLETE', error: null, output: { output: { error: denial } } }}
+      />,
+    );
+    expect(screen.getByTestId('ar-refusal-denial')).toHaveTextContent(denial);
+    expect(screen.getByTestId('ar-refusal')).toHaveTextContent(/not permitted/i);
+    expect(screen.getByTestId('ar-refusal')).toHaveTextContent(/reads COMPLETE/i);
+  });
+
+  it('says plainly when the gate did not refuse', () => {
+    render(
+      <RefusalPanel state={{ jobId: 'j', status: 'COMPLETE', error: null, output: { ok: true } }} />,
+    );
+    expect(screen.getByTestId('ar-refusal-none')).toHaveTextContent(/did not refuse/i);
   });
 });

--- a/__tests__/adaptive-risk-beats.test.tsx
+++ b/__tests__/adaptive-risk-beats.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+const mockResolve = jest.fn();
+jest.mock('@/lib/operations-catalog', () => ({
+  resolveOperationByAddress: (...args: unknown[]) => mockResolve(...args),
+}));
+
+import { runBeat1, readLedger, AGENT_REQUEST_OP } from '@/components/adaptive-risk/beats';
+import { BeatCard } from '@/components/adaptive-risk/BeatCard';
+import { DEFAULT_ADDRESSES } from '@/components/adaptive-risk/fixtures';
+import { ADAPTIVE_RISK_BEATS } from '@/components/adaptive-risk/story';
+
+const beat1 = ADAPTIVE_RISK_BEATS[0];
+
+function finishedJob(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'job-77',
+    isFinished: true,
+    isComplete: true,
+    metadata: { status: 'COMPLETE' },
+    output: { summary: 'flagged dev-9903' },
+    refresh: jest.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('runBeat1', () => {
+  it('dispatches the sentinel task through agent:request', async () => {
+    const invoke = jest.fn(async () => finishedJob());
+    mockResolve.mockResolvedValue({ invoke });
+    const venue = { venueId: 'v', baseUrl: 'http://venue.test' } as never;
+
+    await runBeat1(venue, DEFAULT_ADDRESSES);
+
+    expect(mockResolve).toHaveBeenCalledWith(venue, AGENT_REQUEST_OP);
+    const input = invoke.mock.calls[0][0] as {
+      agentId: string;
+      input: { task: string };
+    };
+    expect(input.agentId).toBe(DEFAULT_ADDRESSES.sentinelAgent);
+    expect(input.input.task).toContain('w/risk/applications');
+    expect(input.input.task).toContain('sharedWith');
+    expect(input.input.task).not.toMatch(/replay/i);
+  });
+});
+
+describe('readLedger', () => {
+  it('reads signals and flags job-free', async () => {
+    const read = jest.fn(async (path: string) =>
+      path.endsWith('flags/dev-9903')
+        ? { exists: true, value: { sharedWith: ['APP-1063', 'APP-1071'] } }
+        : { exists: false },
+    );
+    const list = jest.fn(async (path: string) =>
+      path.endsWith('signals')
+        ? { exists: true, keys: ['APP-1060', 'APP-1061'] }
+        : { exists: true, keys: ['dev-9903'] },
+    );
+    const run = jest.fn();
+    const venue = { workspace: { read, list }, operations: { run } } as never;
+
+    const snapshot = await readLedger(venue, DEFAULT_ADDRESSES);
+
+    expect(snapshot.signalCount).toBe(2);
+    expect(snapshot.flags).toEqual([
+      { device: 'dev-9903', record: { sharedWith: ['APP-1063', 'APP-1071'] } },
+    ]);
+    expect(run).not.toHaveBeenCalled();
+  });
+});
+
+describe('BeatCard', () => {
+  const venue = { venueId: 'test-venue', baseUrl: 'http://venue.test' } as never;
+
+  it('renders narration without a Run button when the beat is not wired', () => {
+    render(<BeatCard beat={beat1} venue={venue} enabled={false} />);
+    expect(screen.getByTestId('ar-beat-silos')).toHaveTextContent(beat1.title);
+    expect(screen.queryByTestId('ar-run-silos')).not.toBeInTheDocument();
+  });
+
+  it('shows the disabled hint until the venue is seeded', () => {
+    render(
+      <BeatCard
+        beat={beat1}
+        venue={venue}
+        enabled={false}
+        disabledHint="Run setup above first"
+        run={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId('ar-run-silos')).toBeDisabled();
+    expect(screen.getByTestId('ar-hint-silos')).toHaveTextContent('Run setup above first');
+  });
+
+  it('runs the beat and renders the job record with a Jobs deep link', async () => {
+    const user = userEvent.setup();
+    const run = jest.fn(async () => finishedJob());
+    render(<BeatCard beat={beat1} venue={venue} enabled run={run} />);
+
+    await user.click(screen.getByTestId('ar-run-silos'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('ar-job-silos')).toHaveTextContent('job-77'),
+    );
+    expect(screen.getByTestId('ar-output-silos')).toHaveTextContent('flagged dev-9903');
+    expect(screen.getByTestId('ar-job-link-silos')).toHaveAttribute(
+      'href',
+      '/venues/test-venue/jobs/job-77',
+    );
+  });
+
+  it("renders a failure with the job's error string, verbatim", async () => {
+    const user = userEvent.setup();
+    const denial =
+      'Capability denied by gate: gate w/ops/risk/limit-gate: Orchestration step 1 failed';
+    const run = jest.fn(async () =>
+      finishedJob({
+        isComplete: false,
+        metadata: { status: 'FAILED', error: denial },
+        output: null,
+      }),
+    );
+    render(<BeatCard beat={beat1} venue={venue} enabled run={run} />);
+
+    await user.click(screen.getByTestId('ar-run-silos'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('ar-error-silos')).toHaveTextContent(denial),
+    );
+  });
+});

--- a/__tests__/adaptive-risk-seed.test.ts
+++ b/__tests__/adaptive-risk-seed.test.ts
@@ -1,0 +1,182 @@
+import '@testing-library/jest-dom';
+import {
+  seedAdaptiveRisk,
+  teardownAdaptiveRisk,
+  verbatimVenueError,
+} from '@/components/adaptive-risk/seed';
+import {
+  APPLICANTS,
+  DEFAULT_ADDRESSES,
+  agentConfigs,
+  limitGateMetadata,
+  policyCheckMetadata,
+} from '@/components/adaptive-risk/fixtures';
+
+// Stub venue in the style of job-free-reads.test.ts: only the surfaces the
+// seeding library touches.
+function stubVenue(overrides: {
+  existingPaths?: Set<string>;
+  existingAgents?: Set<string>;
+  failWriteWith?: Error;
+} = {}) {
+  const existingPaths = overrides.existingPaths ?? new Set<string>();
+  const existingAgents = overrides.existingAgents ?? new Set<string>();
+  const writes: Array<{ path: string; value: unknown }> = [];
+  const deletes: string[] = [];
+  const created: string[] = [];
+  const venue = {
+    venueId: 'did:key:zTestVenue',
+    baseUrl: 'http://venue.test',
+    workspace: {
+      read: jest.fn(async (path: string) => ({ exists: existingPaths.has(path) })),
+      write: jest.fn(async (path: string, value: unknown) => {
+        if (overrides.failWriteWith) throw overrides.failWriteWith;
+        writes.push({ path, value });
+        existingPaths.add(path);
+        return {};
+      }),
+      delete: jest.fn(async (path: string) => {
+        deletes.push(path);
+        return {};
+      }),
+    },
+    assets: {
+      register: jest.fn(async () => ({ id: 'abc123policyhash' })),
+      getMetadata: jest.fn(async (id: string) => {
+        if (id === 'my-own-policy') return { name: 'mine' };
+        throw new Error(`Asset not found: ${id}`);
+      }),
+    },
+    agents: {
+      info: jest.fn(async (id: string) => {
+        if (existingAgents.has(id)) return { agentId: id, status: 'SLEEPING' };
+        throw new Error('404');
+      }),
+      create: jest.fn(async (input: { agentId: string }) => {
+        created.push(input.agentId);
+        existingAgents.add(input.agentId);
+        return { agentId: input.agentId, status: 'SLEEPING', created: true };
+      }),
+      delete: jest.fn(async () => ({})),
+    },
+  };
+  return { venue: venue as never, writes, deletes, created };
+}
+
+describe('fixtures', () => {
+  it('plants APP-1071 wrong twice: amount over authority and a shared device', () => {
+    expect(APPLICANTS).toHaveLength(12);
+    const planted = APPLICANTS.find((a) => a.id === 'APP-1071')!;
+    const sibling = APPLICANTS.find((a) => a.id === 'APP-1063')!;
+    expect(planted.requestedAmount).toBe(2500);
+    expect(planted.device).toBe('dev-9903');
+    expect(sibling.device).toBe('dev-9903');
+    const otherDevices = APPLICANTS.filter((a) => a.device === 'dev-9903');
+    expect(otherDevices).toHaveLength(2);
+  });
+
+  it('encodes the policy as the output schema of a content-addressed op', () => {
+    const policy = policyCheckMetadata();
+    const schema = policy.operation.output.properties.result;
+    expect(schema.properties.amount.maximum).toBe(500);
+    expect(schema.properties.deviceFlagged).toEqual({ const: false });
+  });
+
+  it('gate runs strict so the policy schema is actually enforced', () => {
+    const gate = limitGateMetadata('somehash', DEFAULT_ADDRESSES);
+    expect(gate.operation.strict).toBe(true);
+    expect(gate.operation.steps[1].op).toBe('somehash');
+  });
+
+  it("gates the assessor's issue-limit grant and denies it to the others", () => {
+    const agents = agentConfigs({ ...DEFAULT_ADDRESSES, policyAsset: 'somehash' });
+    const assessorGrant = agents.assessor.config.caps.find(
+      (cap) => cap.with === DEFAULT_ADDRESSES.issueLimit,
+    );
+    expect(assessorGrant).toMatchObject({
+      can: 'invoke',
+      nb: { gate: DEFAULT_ADDRESSES.limitGate },
+    });
+    for (const other of [agents.sentinel, agents.monitor]) {
+      expect(
+        other.config.caps.some((cap) => cap.with === DEFAULT_ADDRESSES.issueLimit),
+      ).toBe(false);
+    }
+  });
+});
+
+describe('seedAdaptiveRisk', () => {
+  it('creates everything on a fresh venue and reports each address', async () => {
+    const { venue, created } = stubVenue();
+    const outcome = await seedAdaptiveRisk(venue, DEFAULT_ADDRESSES);
+    expect(outcome.ok).toBe(true);
+    expect(outcome.policyRef).toBe('abc123policyhash');
+    // policy + 2 ops + 12 applications + 2 windows + pointer + 3 agents
+    expect(outcome.report.items).toHaveLength(21);
+    expect(outcome.report.items.every((i) => i.status === 'created')).toBe(true);
+    expect(created).toEqual(['rk-sentinel', 'rk-assessor', 'rk-monitor']);
+  });
+
+  it('is idempotent: a second run creates nothing', async () => {
+    const { venue } = stubVenue();
+    await seedAdaptiveRisk(venue, DEFAULT_ADDRESSES);
+    const second = await seedAdaptiveRisk(
+      venue,
+      { ...DEFAULT_ADDRESSES, policyAsset: 'my-own-policy' },
+    );
+    expect(second.ok).toBe(true);
+    expect(second.report.items.filter((i) => i.status === 'created')).toHaveLength(0);
+  });
+
+  it('uses a caller-supplied policy address instead of registering', async () => {
+    const { venue } = stubVenue();
+    const outcome = await seedAdaptiveRisk(venue, {
+      ...DEFAULT_ADDRESSES,
+      policyAsset: 'my-own-policy',
+    });
+    expect(outcome.policyRef).toBe('my-own-policy');
+    const stub = venue as unknown as { assets: { register: jest.Mock } };
+    expect(stub.assets.register).not.toHaveBeenCalled();
+  });
+
+  it("stops on refusal and reports the venue's error verbatim", async () => {
+    const denial =
+      'Capability denied: requires crud/write on did:key:zX/w/ops/risk/limit-gate. Your capabilities are: crud/read on w/';
+    const { venue } = stubVenue({ failWriteWith: new Error(denial) });
+    const outcome = await seedAdaptiveRisk(venue, DEFAULT_ADDRESSES);
+    expect(outcome.ok).toBe(false);
+    const failed = outcome.report.items.at(-1)!;
+    expect(failed.status).toBe('failed');
+    expect(failed.error).toBe(denial);
+    // Nothing after the failed item ran.
+    expect(outcome.report.items.filter((i) => i.kind === 'agent')).toHaveLength(0);
+  });
+});
+
+describe('teardownAdaptiveRisk', () => {
+  it('removes the subtree, both op addresses, and the agents', async () => {
+    const { venue, deletes } = stubVenue({
+      existingAgents: new Set(['rk-sentinel', 'rk-assessor', 'rk-monitor']),
+    });
+    const result = await teardownAdaptiveRisk(venue, DEFAULT_ADDRESSES);
+    expect(result.ok).toBe(true);
+    expect(deletes).toEqual(['w/risk', 'w/ops/risk/limit-gate', 'w/ops/risk/issue-limit']);
+    const stub = venue as unknown as { agents: { delete: jest.Mock } };
+    expect(stub.agents.delete).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('verbatimVenueError', () => {
+  it('prefers the job error string over the exception message', () => {
+    const err = Object.assign(new Error('Job failed'), {
+      jobData: { error: 'Capability denied by gate: gate w/ops/risk/limit-gate: ...' },
+    });
+    expect(verbatimVenueError(err)).toMatch(/^Capability denied by gate/);
+  });
+
+  it('falls back to the message, never rewriting it', () => {
+    expect(verbatimVenueError(new Error('403 Forbidden from venue'))).toBe(
+      '403 Forbidden from venue',
+    );
+  });
+});

--- a/__tests__/adaptive-risk-seed.test.ts
+++ b/__tests__/adaptive-risk-seed.test.ts
@@ -20,6 +20,11 @@ function stubVenue(overrides: {
   failWriteWith?: Error;
 } = {}) {
   const existingPaths = overrides.existingPaths ?? new Set<string>();
+  // The venue ships the HITL skill; seeding shadows it into w/skills so a
+  // capped agent can load it.
+  const venueValues: Record<string, unknown> = {
+    'v/skills/hitl': { name: 'hitl', skill: { tools: ['v/ops/hitl/request'] } },
+  };
   const existingAgents = overrides.existingAgents ?? new Set<string>();
   const writes: Array<{ path: string; value: unknown }> = [];
   const deletes: string[] = [];
@@ -28,7 +33,11 @@ function stubVenue(overrides: {
     venueId: 'did:key:zTestVenue',
     baseUrl: 'http://venue.test',
     workspace: {
-      read: jest.fn(async (path: string) => ({ exists: existingPaths.has(path) })),
+      read: jest.fn(async (path: string) =>
+        path in venueValues
+          ? { exists: true, value: venueValues[path] }
+          : { exists: existingPaths.has(path) },
+      ),
       write: jest.fn(async (path: string, value: unknown) => {
         if (overrides.failWriteWith) throw overrides.failWriteWith;
         writes.push({ path, value });
@@ -111,8 +120,9 @@ describe('seedAdaptiveRisk', () => {
     const outcome = await seedAdaptiveRisk(venue, DEFAULT_ADDRESSES);
     expect(outcome.ok).toBe(true);
     expect(outcome.policyRef).toBe('abc123policyhash');
-    // policy + 2 ops + 12 applications + 2 windows + pointer + 3 agents
-    expect(outcome.report.items).toHaveLength(21);
+    // policy + 2 ops + 12 applications + 2 windows + pointer
+    // + shadowed hitl skill + 3 agents
+    expect(outcome.report.items).toHaveLength(22);
     expect(outcome.report.items.every((i) => i.status === 'created')).toBe(true);
     expect(created).toEqual(['rk-sentinel', 'rk-assessor', 'rk-monitor']);
   });
@@ -150,6 +160,25 @@ describe('seedAdaptiveRisk', () => {
     expect(failed.error).toBe(denial);
     // Nothing after the failed item ran.
     expect(outcome.report.items.filter((i) => i.kind === 'agent')).toHaveLength(0);
+  });
+});
+
+describe('HITL skill shadowing', () => {
+  it("copies the venue's hitl skill into the caller's own namespace", async () => {
+    const { venue, writes } = stubVenue();
+    await seedAdaptiveRisk(venue, DEFAULT_ADDRESSES);
+    const shadow = writes.find((w) => w.path === 'w/skills/hitl');
+    expect(shadow).toBeDefined();
+    expect(shadow!.value).toMatchObject({ name: 'hitl' });
+  });
+
+  it('fails honestly when the venue ships no hitl skill', async () => {
+    const { venue } = stubVenue();
+    const stub = venue as unknown as { workspace: { read: jest.Mock } };
+    stub.workspace.read.mockImplementation(async () => ({ exists: false }));
+    const outcome = await seedAdaptiveRisk(venue, DEFAULT_ADDRESSES);
+    expect(outcome.ok).toBe(false);
+    expect(outcome.report.items.at(-1)!.error).toMatch(/No HITL skill at v\/skills\/hitl/);
   });
 });
 

--- a/__tests__/hitl.test.ts
+++ b/__tests__/hitl.test.ts
@@ -157,3 +157,31 @@ describe('respondToHitl', () => {
     expect(runMock.mock.calls[0][0]).not.toHaveProperty('grants');
   });
 });
+
+describe('respondToHitl error surfacing', () => {
+  it("surfaces the venue's reason, not just the job id", async () => {
+    const reason =
+      'echoed grant 0 was not offered by the choices made — the venue issues only offered-and-triggered grants';
+    const { venue } = venueWithInbox({});
+    venue.workspace.read = jest.fn().mockResolvedValue({
+      exists: true, value: { operation: { adapter: 'hitl:respond' } },
+    });
+    runMock.mockRejectedValueOnce(
+      Object.assign(new Error('Job 0xabc FAILED'), { jobData: { error: reason } }),
+    );
+    await expect(
+      respondToHitl(venue, { id: 'r1', outcome: 'answer' }),
+    ).rejects.toThrow(reason);
+  });
+
+  it('rethrows untouched when the venue gave no reason', async () => {
+    const { venue } = venueWithInbox({});
+    venue.workspace.read = jest.fn().mockResolvedValue({
+      exists: true, value: { operation: { adapter: 'hitl:respond' } },
+    });
+    runMock.mockRejectedValueOnce(new Error('Failed to fetch'));
+    await expect(
+      respondToHitl(venue, { id: 'r1', outcome: 'answer' }),
+    ).rejects.toThrow('Failed to fetch');
+  });
+});

--- a/src/app/(demo)/demos/[slug]/page.tsx
+++ b/src/app/(demo)/demos/[slug]/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from "next/navigation";
+import { ContentLayout } from "@/components/admin-panel/content-layout";
+import { TopBar } from "@/components/admin-panel/TopBar";
+import { PageHeading } from "@/components/PageHeading";
+import { demoBySlug } from "@/lib/demos";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const demo = demoBySlug(slug);
+  if (!demo) notFound();
+
+  return (
+    <ContentLayout>
+      <TopBar />
+      <div className="py-4">
+        <PageHeading
+          className="mb-2"
+          size="sm"
+          align="left"
+          text={demo.title.text}
+          highlight={demo.title.highlight}
+        />
+        <p className="text-sm text-muted-foreground mb-6">{demo.blurb}</p>
+        <demo.Component />
+      </div>
+    </ContentLayout>
+  );
+}

--- a/src/app/(demo)/demos/page.tsx
+++ b/src/app/(demo)/demos/page.tsx
@@ -1,9 +1,10 @@
-"use client";
-
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import { ContentLayout } from "@/components/admin-panel/content-layout";
 import { TopBar } from "@/components/admin-panel/TopBar";
-import { JobLifecycleDemo } from "@/components/JobLifecycleDemo";
 import { PageHeading } from "@/components/PageHeading";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DEMOS } from "@/lib/demos";
 
 export default function DemosPage() {
   return (
@@ -14,13 +15,37 @@ export default function DemosPage() {
           className="mb-2"
           size="sm"
           align="left"
-          text="Run a job with the"
-          highlight="TypeScript SDK"
+          text="Guided"
+          highlight="demos"
         />
         <p className="text-sm text-muted-foreground mb-6">
-          A live walkthrough of how the SDK executes work on a venue.
+          Live walkthroughs that run real jobs on the venue you have selected.
         </p>
-        <JobLifecycleDemo />
+        <div className="grid gap-4 sm:grid-cols-2 max-w-3xl">
+          {DEMOS.map((demo) => (
+            <Link
+              key={demo.slug}
+              href={`/demos/${demo.slug}`}
+              data-testid={`demo-card-${demo.slug}`}
+              className="group"
+            >
+              <Card className="h-full transition-colors group-hover:border-primary/60">
+                <CardHeader>
+                  <CardTitle className="text-base flex items-center gap-2">
+                    {demo.title.text} {demo.title.highlight}
+                    <ArrowRight
+                      className="size-4 opacity-0 group-hover:opacity-100 transition-opacity"
+                      aria-hidden="true"
+                    />
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground">{demo.blurb}</p>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
       </div>
     </ContentLayout>
   );

--- a/src/app/(demo)/inbox/page.tsx
+++ b/src/app/(demo)/inbox/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
 import { ContentLayout } from "@/components/admin-panel/content-layout";
 import { TopBar } from "@/components/admin-panel/TopBar";
 import { HitlInbox } from "@/components/HitlInbox";
@@ -8,6 +9,9 @@ import { useIsAuthenticated } from "@/hooks/use-auth";
 
 export default function HitlPage() {
   const isAuthenticated = useIsAuthenticated();
+  // Deep link target, e.g. /inbox?requestId=<id> — same pattern as
+  // /agents/explorer?agentId=…
+  const requestId = useSearchParams().get("requestId") ?? undefined;
 
   return (
     <ContentLayout>
@@ -16,7 +20,7 @@ export default function HitlPage() {
         <PageHeading className="mb-4" size="sm" align="left" text="Manage your" highlight="Inbox" />
 
         {isAuthenticated ? (
-          <HitlInbox />
+          <HitlInbox initialRequestId={requestId} />
         ) : (
           <p className="text-sm text-muted-foreground py-8 text-center">
             Sign in to view requests awaiting your decision.

--- a/src/components/HitlInbox.tsx
+++ b/src/components/HitlInbox.tsx
@@ -197,7 +197,12 @@ function AskControl({
   );
 }
 
-export function HitlInbox() {
+/**
+ * @param initialRequestId Opens this request expanded on mount, for deep links
+ *   such as /inbox?requestId=… — the demo pages send a viewer to the ask they
+ *   just raised rather than rebuilding an approval surface of their own.
+ */
+export function HitlInbox({ initialRequestId }: { initialRequestId?: string } = {}) {
   const venue = useAuthenticatedVenue();
   const { requests, loading, error, refresh } = useHitlRequests();
   // Whether stored credentials exist for *the venue actually being read*. The
@@ -215,7 +220,7 @@ export function HitlInbox() {
   const [statusFilter, setStatusFilter] = useState<string[]>([]);
   // Only one request is ever open for editing, so its draft can live here
   // rather than in a map keyed by request id.
-  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(initialRequestId ?? null);
   const [answers, setAnswers] = useState<Record<string, HitlAnswer>>({});
   const [comment, setComment] = useState("");
   const [submittingId, setSubmittingId] = useState<string | null>(null);

--- a/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
+++ b/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import { useState } from "react";
 import { Landmark, ShieldAlert } from "lucide-react";
 import { useAuthenticatedVenue } from "@/hooks/use-authenticated-venue";
 import { useIsAuthenticated } from "@/hooks/use-auth";
+import { useAdaptiveRiskConfig } from "@/hooks/use-adaptive-risk-config";
 import { ADAPTIVE_RISK_BEATS } from "./story";
 import { SetupPanel } from "./SetupPanel";
+import { BeatCard } from "./BeatCard";
+import { LedgerPanel } from "./LedgerPanel";
+import { runBeat1 } from "./beats";
 
 // Adaptive Risk: a guided walkthrough over real venue calls. Fictional issuer
 // Meridian Bank Singapore, thin-file starter card, base limit S$500, twelve
@@ -14,6 +19,15 @@ import { SetupPanel } from "./SetupPanel";
 export function AdaptiveRiskDemo() {
   const venue = useAuthenticatedVenue();
   const isAuthenticated = useIsAuthenticated();
+  const { addresses, reports } = useAdaptiveRiskConfig();
+  const [ledgerRefresh, setLedgerRefresh] = useState(0);
+
+  const seeded = !!venue && !!reports[venue.venueId];
+  const beatHint = !venue
+    ? "Select a venue first."
+    : !isAuthenticated
+      ? "Sign in first."
+      : "Run setup above first — the beats need the seeded agents and fixtures.";
 
   return (
     <div className="flex flex-col gap-6 max-w-3xl">
@@ -37,18 +51,27 @@ export function AdaptiveRiskDemo() {
       <section aria-label="Beats" className="flex flex-col gap-3">
         <ol className="flex flex-col gap-3">
           {ADAPTIVE_RISK_BEATS.map((beat) => (
-            <li
+            <BeatCard
               key={beat.id}
-              data-testid={`ar-beat-${beat.id}`}
-              className="rounded-lg border p-4"
+              beat={beat}
+              venue={venue}
+              enabled={seeded}
+              disabledHint={beatHint}
+              run={beat.id === "silos" ? (v) => runBeat1(v, addresses) : undefined}
+              onSettled={
+                beat.id === "silos"
+                  ? () => setLedgerRefresh((token) => token + 1)
+                  : undefined
+              }
             >
-              <p className="text-sm font-medium">{beat.title}</p>
-              <p className="text-sm text-muted-foreground mt-1">{beat.narration}</p>
-              <p className="text-xs text-muted-foreground mt-2">
-                <span className="font-medium text-foreground">Watch:</span>{" "}
-                {beat.watch}
-              </p>
-            </li>
+              {beat.id === "silos" && (
+                <LedgerPanel
+                  venue={venue}
+                  addresses={addresses}
+                  refreshToken={ledgerRefresh}
+                />
+              )}
+            </BeatCard>
           ))}
         </ol>
       </section>

--- a/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
+++ b/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
@@ -10,6 +10,9 @@ import { SetupPanel } from "./SetupPanel";
 import { BeatCard } from "./BeatCard";
 import { LedgerPanel } from "./LedgerPanel";
 import { DecisionsPanel } from "./DecisionsPanel";
+import { PolicyLinks } from "./PolicyLinks";
+import { RefusalPanel } from "./RefusalPanel";
+import type { BeatJobState } from "./BeatCard";
 import { runBeat1, runAssessorBeat } from "./beats";
 import { APPLICANTS, STARTER_CARD_LIMIT } from "./fixtures";
 
@@ -24,6 +27,7 @@ export function AdaptiveRiskDemo() {
   const { addresses, reports } = useAdaptiveRiskConfig();
   const [ledgerRefresh, setLedgerRefresh] = useState(0);
   const [decisionsRefresh, setDecisionsRefresh] = useState(0);
+  const [refusalState, setRefusalState] = useState<BeatJobState | null>(null);
 
   // Beat 2's clean applicant: asks for exactly the base limit on a device
   // nobody else shares, so the gate has nothing to object to.
@@ -31,6 +35,14 @@ export function AdaptiveRiskDemo() {
     (a) =>
       a.requestedAmount <= STARTER_CARD_LIMIT &&
       APPLICANTS.filter((other) => other.device === a.device).length === 1,
+  )!;
+
+  // Beat 3's planted case: over the base limit AND sharing a device with
+  // another application, so the gate has two independent reasons to refuse.
+  const planted = APPLICANTS.find(
+    (a) =>
+      a.requestedAmount > STARTER_CARD_LIMIT &&
+      APPLICANTS.filter((other) => other.device === a.device).length > 1,
   )!;
 
   const seeded = !!venue && !!reports[venue.venueId];
@@ -80,14 +92,32 @@ export function AdaptiveRiskDemo() {
                           clean.requestedAmount,
                           clean.device,
                         )
-                    : undefined
+                    : beat.id === "refusal"
+                      ? (v) => {
+                          // Drop the previous verdict before re-running, so a
+                          // stale refusal never sits next to a live job.
+                          setRefusalState(null);
+                          return runAssessorBeat(
+                            v,
+                            addresses,
+                            planted.id,
+                            planted.requestedAmount,
+                            planted.device,
+                          );
+                        }
+                      : undefined
               }
               onSettled={
                 beat.id === "silos"
                   ? () => setLedgerRefresh((token) => token + 1)
                   : beat.id === "clean-approval"
                     ? () => setDecisionsRefresh((token) => token + 1)
-                    : undefined
+                    : beat.id === "refusal"
+                      ? (state) => {
+                          setRefusalState(state);
+                          setDecisionsRefresh((token) => token + 1);
+                        }
+                      : undefined
               }
             >
               {beat.id === "silos" && (
@@ -103,6 +133,18 @@ export function AdaptiveRiskDemo() {
                   addresses={addresses}
                   refreshToken={decisionsRefresh}
                 />
+              )}
+              {beat.id === "refusal" && (
+                <>
+                  <RefusalPanel state={refusalState} />
+                  <PolicyLinks venue={venue} addresses={addresses} />
+                  <DecisionsPanel
+                    venue={venue}
+                    addresses={addresses}
+                    refreshToken={decisionsRefresh}
+                    absenceOf={planted.id}
+                  />
+                </>
               )}
             </BeatCard>
           ))}

--- a/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
+++ b/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { Landmark, ShieldAlert } from "lucide-react";
+import { useAuthenticatedVenue } from "@/hooks/use-authenticated-venue";
+import { useIsAuthenticated } from "@/hooks/use-auth";
+import { ADAPTIVE_RISK_BEATS } from "./story";
+
+// Adaptive Risk: a guided walkthrough over real venue calls. Fictional issuer
+// Meridian Bank Singapore, thin-file starter card, base limit S$500, twelve
+// synthetic applicants. Three agents and one gate, created by the seeding
+// step; every beat runs a real job on the selected venue and renders the real
+// record — a failed call is shown as a failure, never animated over.
+export function AdaptiveRiskDemo() {
+  const venue = useAuthenticatedVenue();
+  const isAuthenticated = useIsAuthenticated();
+
+  return (
+    <div className="flex flex-col gap-6 max-w-3xl">
+      <ScenarioIntro />
+      <HonestyPanel />
+
+      {!venue && (
+        <p className="text-sm text-muted-foreground" data-testid="ar-no-venue">
+          Select a venue to run this demo.
+        </p>
+      )}
+      {venue && !isAuthenticated && (
+        <p className="text-sm text-muted-foreground" data-testid="ar-no-auth">
+          Sign in to run this demo — seeding registers agents and fixtures under
+          your own identity, and the Inbox beat needs you to answer as yourself.
+        </p>
+      )}
+
+      <section aria-label="Set up this demo" data-testid="ar-setup">
+        <h3 className="text-base font-semibold mb-1">Set up this demo</h3>
+        <p className="text-sm text-muted-foreground">
+          The seeding panel lands in the next slice: it will show every
+          operation, agent and fixture address in an editable form before
+          registering anything, report exactly what it created, and offer a
+          teardown.
+        </p>
+      </section>
+
+      <section aria-label="Beats" className="flex flex-col gap-3">
+        <ol className="flex flex-col gap-3">
+          {ADAPTIVE_RISK_BEATS.map((beat) => (
+            <li
+              key={beat.id}
+              data-testid={`ar-beat-${beat.id}`}
+              className="rounded-lg border p-4"
+            >
+              <p className="text-sm font-medium">{beat.title}</p>
+              <p className="text-sm text-muted-foreground mt-1">{beat.narration}</p>
+              <p className="text-xs text-muted-foreground mt-2">
+                <span className="font-medium text-foreground">Watch:</span>{" "}
+                {beat.watch}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </section>
+    </div>
+  );
+}
+
+function ScenarioIntro() {
+  return (
+    <div className="flex items-start gap-3">
+      <Landmark className="size-5 mt-0.5 text-primary shrink-0" aria-hidden="true" />
+      <p className="text-sm text-muted-foreground">
+        Meridian Bank Singapore — a fictional issuer — runs a thin-file starter
+        card with a base limit of S$500. A fraud agent, a credit agent and a
+        drift monitor share one venue. The credit agent cannot issue a limit
+        unless the fraud agent&apos;s signals pass a policy gate: the two are not
+        integrated by a model, they are joined at the execution layer, and the
+        join is enforced.
+      </p>
+    </div>
+  );
+}
+
+// The honesty panel is a permanent part of the page, not a dismissible note:
+// a reviewer who catches an unlabelled simulation discards everything else.
+function HonestyPanel() {
+  return (
+    <aside
+      role="note"
+      aria-label="What is real in this demo"
+      data-testid="ar-honesty"
+      className="rounded-lg border bg-muted/40 p-4"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <ShieldAlert className="size-4 text-primary" aria-hidden="true" />
+        <h3 className="text-sm font-semibold">What is real here, and what is not</h3>
+      </div>
+      <ul className="list-disc pl-5 text-sm text-muted-foreground space-y-1">
+        <li>
+          All data is synthetic: twelve applicants, one fictional bank. Nothing
+          here describes a real person or a real lender.
+        </li>
+        <li>
+          Covia has no training loop, model registry or drift metric. The drift
+          event in beat 4 is a fixture swap and the threshold breach is
+          scripted. The escalation, the ask, the approval, the minted grant and
+          the resumed job are real venue operations.
+        </li>
+        <li>
+          The agents are LLM components executing policy, not trained
+          scorecards.
+        </li>
+        <li>
+          If your venue runs <code className="font-mono text-xs">auth.public.caps: &quot;unrestricted&quot;</code>{" "}
+          so seeding can write, that widens the anonymous caller only —
+          per-agent capability scopes, the gate and the grants in this demo are
+          still enforced per agent.
+        </li>
+      </ul>
+    </aside>
+  );
+}

--- a/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
+++ b/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
@@ -12,8 +12,9 @@ import { LedgerPanel } from "./LedgerPanel";
 import { DecisionsPanel } from "./DecisionsPanel";
 import { PolicyLinks } from "./PolicyLinks";
 import { RefusalPanel } from "./RefusalPanel";
+import { EscalationPanel } from "./EscalationPanel";
 import type { BeatJobState } from "./BeatCard";
-import { runBeat1, runAssessorBeat } from "./beats";
+import { runBeat1, runAssessorBeat, runBeat4, swapToWeekTwo } from "./beats";
 import { APPLICANTS, STARTER_CARD_LIMIT } from "./fixtures";
 
 // Adaptive Risk: a guided walkthrough over real venue calls. Fictional issuer
@@ -24,10 +25,12 @@ import { APPLICANTS, STARTER_CARD_LIMIT } from "./fixtures";
 export function AdaptiveRiskDemo() {
   const venue = useAuthenticatedVenue();
   const isAuthenticated = useIsAuthenticated();
-  const { addresses, reports } = useAdaptiveRiskConfig();
+  const { addresses, reports, escalations, setEscalation } = useAdaptiveRiskConfig();
   const [ledgerRefresh, setLedgerRefresh] = useState(0);
   const [decisionsRefresh, setDecisionsRefresh] = useState(0);
   const [refusalState, setRefusalState] = useState<BeatJobState | null>(null);
+  const [driftState, setDriftState] = useState<BeatJobState | null>(null);
+  const [monitorAnalysis, setMonitorAnalysis] = useState<BeatJobState | null>(null);
 
   // Beat 2's clean applicant: asks for exactly the base limit on a device
   // nobody else shares, so the gate has nothing to object to.
@@ -105,7 +108,31 @@ export function AdaptiveRiskDemo() {
                             planted.device,
                           );
                         }
-                      : undefined
+                      : beat.id === "drift"
+                        ? async (v) => {
+                            setDriftState(null);
+                            setMonitorAnalysis(null);
+                            // The drift IS this fixture swap — labelled as
+                            // such on screen, not smuggled in as a metric.
+                            await swapToWeekTwo(v, addresses);
+                            const { analysis, ask } = await runBeat4(v, addresses);
+                            // Persist before returning: the viewer is about to
+                            // leave for the Inbox, and React state will not
+                            // survive that round trip.
+                            setEscalation(v.venueId, {
+                              analysisJobId: analysis.id,
+                              askJobId: ask.id,
+                            });
+                            setMonitorAnalysis({
+                              jobId: analysis.id,
+                              status: analysis.metadata?.status ?? null,
+                              error: analysis.metadata?.error ?? null,
+                              output: analysis.isComplete ? analysis.output : null,
+                            });
+                            // The card tracks the ASK — it is the job that parks.
+                            return ask;
+                          }
+                        : undefined
               }
               onSettled={
                 beat.id === "silos"
@@ -117,7 +144,9 @@ export function AdaptiveRiskDemo() {
                           setRefusalState(state);
                           setDecisionsRefresh((token) => token + 1);
                         }
-                      : undefined
+                      : beat.id === "drift"
+                        ? (state) => setDriftState(state)
+                        : undefined
               }
             >
               {beat.id === "silos" && (
@@ -132,6 +161,14 @@ export function AdaptiveRiskDemo() {
                   venue={venue}
                   addresses={addresses}
                   refreshToken={decisionsRefresh}
+                />
+              )}
+              {beat.id === "drift" && (
+                <EscalationPanel
+                  venue={venue}
+                  state={driftState}
+                  analysis={monitorAnalysis}
+                  escalation={venue ? escalations[venue.venueId] ?? null : null}
                 />
               )}
               {beat.id === "refusal" && (
@@ -198,6 +235,14 @@ function HonestyPanel() {
         <li>
           The agents are LLM components executing policy, not trained
           scorecards.
+        </li>
+        <li>
+          Beat 4&apos;s approval mints a real venue-signed grant with a real
+          expiry, and you can verify it here. It confers write access to the
+          reviewed-limit record — it does not silently widen the credit
+          agent&apos;s authority, and the gate&apos;s device-flag condition keeps
+          applying whatever the limit says. Applying a reviewed limit to the
+          live policy is an operator action, outside this demo.
         </li>
         <li>
           If your venue runs <code className="font-mono text-xs">auth.public.caps: &quot;unrestricted&quot;</code>{" "}

--- a/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
+++ b/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
@@ -4,6 +4,7 @@ import { Landmark, ShieldAlert } from "lucide-react";
 import { useAuthenticatedVenue } from "@/hooks/use-authenticated-venue";
 import { useIsAuthenticated } from "@/hooks/use-auth";
 import { ADAPTIVE_RISK_BEATS } from "./story";
+import { SetupPanel } from "./SetupPanel";
 
 // Adaptive Risk: a guided walkthrough over real venue calls. Fictional issuer
 // Meridian Bank Singapore, thin-file starter card, base limit S$500, twelve
@@ -31,15 +32,7 @@ export function AdaptiveRiskDemo() {
         </p>
       )}
 
-      <section aria-label="Set up this demo" data-testid="ar-setup">
-        <h3 className="text-base font-semibold mb-1">Set up this demo</h3>
-        <p className="text-sm text-muted-foreground">
-          The seeding panel lands in the next slice: it will show every
-          operation, agent and fixture address in an editable form before
-          registering anything, report exactly what it created, and offer a
-          teardown.
-        </p>
-      </section>
+      <SetupPanel venue={venue} isAuthenticated={isAuthenticated} />
 
       <section aria-label="Beats" className="flex flex-col gap-3">
         <ol className="flex flex-col gap-3">

--- a/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
+++ b/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
@@ -13,6 +13,7 @@ import { DecisionsPanel } from "./DecisionsPanel";
 import { PolicyLinks } from "./PolicyLinks";
 import { RefusalPanel } from "./RefusalPanel";
 import { EscalationPanel } from "./EscalationPanel";
+import { ReconstructionPanel } from "./ReconstructionPanel";
 import type { BeatJobState } from "./BeatCard";
 import { runBeat1, runAssessorBeat, runBeat4, swapToWeekTwo } from "./beats";
 import { APPLICANTS, STARTER_CARD_LIMIT } from "./fixtures";
@@ -25,7 +26,14 @@ import { APPLICANTS, STARTER_CARD_LIMIT } from "./fixtures";
 export function AdaptiveRiskDemo() {
   const venue = useAuthenticatedVenue();
   const isAuthenticated = useIsAuthenticated();
-  const { addresses, reports, escalations, setEscalation } = useAdaptiveRiskConfig();
+  const {
+    addresses,
+    reports,
+    escalations,
+    setEscalation,
+    refusals,
+    setRefusal,
+  } = useAdaptiveRiskConfig();
   const [ledgerRefresh, setLedgerRefresh] = useState(0);
   const [decisionsRefresh, setDecisionsRefresh] = useState(0);
   const [refusalState, setRefusalState] = useState<BeatJobState | null>(null);
@@ -143,6 +151,14 @@ export function AdaptiveRiskDemo() {
                       ? (state) => {
                           setRefusalState(state);
                           setDecisionsRefresh((token) => token + 1);
+                          // Beat 5 reconstructs this exact record later, so the
+                          // id has to outlive the page.
+                          if (venue && state.jobId) {
+                            setRefusal(venue.venueId, {
+                              jobId: state.jobId,
+                              applicant: planted.id,
+                            });
+                          }
                         }
                       : beat.id === "drift"
                         ? (state) => setDriftState(state)
@@ -169,6 +185,13 @@ export function AdaptiveRiskDemo() {
                   state={driftState}
                   analysis={monitorAnalysis}
                   escalation={venue ? escalations[venue.venueId] ?? null : null}
+                />
+              )}
+              {beat.id === "reconstruction" && (
+                <ReconstructionPanel
+                  venue={venue}
+                  jobId={venue ? refusals[venue.venueId]?.jobId ?? null : null}
+                  label={`the ${planted.id} refusal`}
                 />
               )}
               {beat.id === "refusal" && (

--- a/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
+++ b/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
@@ -237,8 +237,10 @@ function HonestyPanel() {
           scorecards.
         </li>
         <li>
-          Beat 4&apos;s approval mints a real venue-signed grant with a real
-          expiry, and you can verify it here. It confers write access to the
+          Beat 4&apos;s approval produces a real capability grant with a real
+          expiry, signed by you with your own device key — this venue cannot
+          root-sign a grant over a self-sovereign holder&apos;s namespace, and
+          says so. You can verify it here. It confers write access to the
           reviewed-limit record — it does not silently widen the credit
           agent&apos;s authority, and the gate&apos;s device-flag condition keeps
           applying whatever the limit says. Applying a reviewed limit to the

--- a/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
+++ b/src/components/adaptive-risk/AdaptiveRiskDemo.tsx
@@ -9,7 +9,9 @@ import { ADAPTIVE_RISK_BEATS } from "./story";
 import { SetupPanel } from "./SetupPanel";
 import { BeatCard } from "./BeatCard";
 import { LedgerPanel } from "./LedgerPanel";
-import { runBeat1 } from "./beats";
+import { DecisionsPanel } from "./DecisionsPanel";
+import { runBeat1, runAssessorBeat } from "./beats";
+import { APPLICANTS, STARTER_CARD_LIMIT } from "./fixtures";
 
 // Adaptive Risk: a guided walkthrough over real venue calls. Fictional issuer
 // Meridian Bank Singapore, thin-file starter card, base limit S$500, twelve
@@ -21,6 +23,15 @@ export function AdaptiveRiskDemo() {
   const isAuthenticated = useIsAuthenticated();
   const { addresses, reports } = useAdaptiveRiskConfig();
   const [ledgerRefresh, setLedgerRefresh] = useState(0);
+  const [decisionsRefresh, setDecisionsRefresh] = useState(0);
+
+  // Beat 2's clean applicant: asks for exactly the base limit on a device
+  // nobody else shares, so the gate has nothing to object to.
+  const clean = APPLICANTS.find(
+    (a) =>
+      a.requestedAmount <= STARTER_CARD_LIMIT &&
+      APPLICANTS.filter((other) => other.device === a.device).length === 1,
+  )!;
 
   const seeded = !!venue && !!reports[venue.venueId];
   const beatHint = !venue
@@ -57,11 +68,26 @@ export function AdaptiveRiskDemo() {
               venue={venue}
               enabled={seeded}
               disabledHint={beatHint}
-              run={beat.id === "silos" ? (v) => runBeat1(v, addresses) : undefined}
+              run={
+                beat.id === "silos"
+                  ? (v) => runBeat1(v, addresses)
+                  : beat.id === "clean-approval"
+                    ? (v) =>
+                        runAssessorBeat(
+                          v,
+                          addresses,
+                          clean.id,
+                          clean.requestedAmount,
+                          clean.device,
+                        )
+                    : undefined
+              }
               onSettled={
                 beat.id === "silos"
                   ? () => setLedgerRefresh((token) => token + 1)
-                  : undefined
+                  : beat.id === "clean-approval"
+                    ? () => setDecisionsRefresh((token) => token + 1)
+                    : undefined
               }
             >
               {beat.id === "silos" && (
@@ -69,6 +95,13 @@ export function AdaptiveRiskDemo() {
                   venue={venue}
                   addresses={addresses}
                   refreshToken={ledgerRefresh}
+                />
+              )}
+              {beat.id === "clean-approval" && (
+                <DecisionsPanel
+                  venue={venue}
+                  addresses={addresses}
+                  refreshToken={decisionsRefresh}
                 />
               )}
             </BeatCard>

--- a/src/components/adaptive-risk/BeatCard.tsx
+++ b/src/components/adaptive-risk/BeatCard.tsx
@@ -61,7 +61,12 @@ export function BeatCard({
       const started = await run(venue);
       if (!owns()) return;
       setJob({ jobId: started.id, status: started.metadata?.status ?? null, error: null, output: null });
-      while (!started.isFinished) {
+      // A job parked awaiting a human (INPUT_REQUIRED) is NOT finished, but it
+      // is settled as far as this beat is concerned — the next move is the
+      // person's. Polling until isFinished would spin forever and leave the
+      // Run button disabled for as long as the ask goes unanswered.
+      const settledEnough = () => started.isFinished || started.isPaused;
+      while (!settledEnough()) {
         await new Promise((resolve) => setTimeout(resolve, POLL_MS));
         if (!owns()) return;
         await started.refresh();

--- a/src/components/adaptive-risk/BeatCard.tsx
+++ b/src/components/adaptive-risk/BeatCard.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import type { Job, Venue } from "@covia/covia-sdk";
+import { ExternalLink, PlayCircle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { StatusBadge } from "@/components/StatusBadge";
+import { Spinner } from "@/components/ui/shadcn-io/spinner";
+import { notifyError } from "@/lib/notify";
+import { verbatimVenueError } from "./seed";
+import type { AdaptiveRiskBeat } from "./story";
+
+// One beat: narration, a Run button, then the real job record. A failed call
+// renders as a failure with the venue's error string verbatim — never
+// paraphrased (deliberately not friendlyError), never animated over.
+
+const POLL_MS = 1000;
+
+export type BeatJobState = {
+  jobId: string | null;
+  status: string | null;
+  error: string | null;
+  output: unknown;
+};
+
+export function BeatCard({
+  beat,
+  venue,
+  enabled,
+  disabledHint,
+  run,
+  onSettled,
+  children,
+}: {
+  beat: AdaptiveRiskBeat;
+  venue: Venue | null;
+  enabled: boolean;
+  disabledHint?: string;
+  /** Starts the beat's real job. Absent = beat not wired yet (renders narration only). */
+  run?: (venue: Venue) => Promise<Job>;
+  /** Called once the job reaches a terminal state. */
+  onSettled?: (state: BeatJobState) => void;
+  children?: React.ReactNode;
+}) {
+  const [running, setRunning] = useState(false);
+  const [job, setJob] = useState<BeatJobState | null>(null);
+  // Ownership guard against overlapping runs and unmount, per the
+  // use-execution-lifecycle idiom.
+  const generation = useRef(0);
+  useEffect(() => () => void (generation.current += 1), []);
+
+  const start = async () => {
+    if (!venue || !run) return;
+    const gen = ++generation.current;
+    const owns = () => generation.current === gen;
+    setRunning(true);
+    setJob(null);
+    try {
+      const started = await run(venue);
+      if (!owns()) return;
+      setJob({ jobId: started.id, status: started.metadata?.status ?? null, error: null, output: null });
+      while (!started.isFinished) {
+        await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+        if (!owns()) return;
+        await started.refresh();
+        if (!owns()) return;
+        setJob({
+          jobId: started.id,
+          status: started.metadata?.status ?? null,
+          error: started.metadata?.error ?? null,
+          output: null,
+        });
+      }
+      const settled: BeatJobState = {
+        jobId: started.id,
+        status: started.metadata?.status ?? null,
+        error: started.metadata?.error ?? null,
+        output: started.isComplete ? started.output : null,
+      };
+      setJob(settled);
+      onSettled?.(settled);
+    } catch (err) {
+      if (!owns()) return;
+      // An invoke refused before a job existed still gets shown, verbatim.
+      const settled: BeatJobState = {
+        jobId: job?.jobId ?? null,
+        status: "FAILED",
+        error: verbatimVenueError(err),
+        output: null,
+      };
+      setJob(settled);
+      onSettled?.(settled);
+      notifyError(`Unable to run ${beat.title}`, err, venue.baseUrl);
+    } finally {
+      if (owns()) setRunning(false);
+    }
+  };
+
+  return (
+    <li data-testid={`ar-beat-${beat.id}`} className="rounded-lg border p-4 flex flex-col gap-2">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium">{beat.title}</p>
+          <p className="text-sm text-muted-foreground mt-1">{beat.narration}</p>
+          <p className="text-xs text-muted-foreground mt-2">
+            <span className="font-medium text-foreground">Watch:</span> {beat.watch}
+          </p>
+        </div>
+        {run && (
+          <Button
+            size="sm"
+            data-testid={`ar-run-${beat.id}`}
+            onClick={start}
+            disabled={!enabled || running}
+          >
+            {running ? <Spinner variant="ellipsis" /> : <PlayCircle className="size-4" />}
+            Run
+          </Button>
+        )}
+      </div>
+      {run && !enabled && disabledHint && (
+        <p className="text-xs text-muted-foreground" data-testid={`ar-hint-${beat.id}`}>
+          {disabledHint}
+        </p>
+      )}
+
+      {job && (
+        <div className="rounded border bg-muted/30 p-3 flex flex-col gap-2" data-testid={`ar-job-${beat.id}`}>
+          <div className="flex items-center gap-2 text-sm">
+            <StatusBadge status={job.status ?? undefined} kind="job" as="pill" />
+            {job.jobId && (
+              <>
+                <Badge variant="outline" className="font-mono text-[11px]">{job.jobId}</Badge>
+                {venue && (
+                  <Link
+                    className="inline-flex items-center gap-1 text-xs underline underline-offset-2"
+                    data-testid={`ar-job-link-${beat.id}`}
+                    href={`/venues/${encodeURIComponent(venue.venueId)}/jobs/${job.jobId}`}
+                  >
+                    open in Jobs <ExternalLink className="size-3" />
+                  </Link>
+                )}
+              </>
+            )}
+          </div>
+          {job.error && (
+            <pre
+              data-testid={`ar-error-${beat.id}`}
+              className="text-xs text-destructive whitespace-pre-wrap break-all bg-muted rounded p-2"
+            >
+              {job.error}
+            </pre>
+          )}
+          {job.output != null && (
+            <pre
+              data-testid={`ar-output-${beat.id}`}
+              className="text-xs whitespace-pre-wrap break-all bg-muted rounded p-2 max-h-56 overflow-y-auto"
+            >
+              {JSON.stringify(job.output, null, 2)}
+            </pre>
+          )}
+        </div>
+      )}
+      {children}
+    </li>
+  );
+}

--- a/src/components/adaptive-risk/DecisionsPanel.tsx
+++ b/src/components/adaptive-risk/DecisionsPanel.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { Venue } from "@covia/covia-sdk";
+import { RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { notifyError } from "@/lib/notify";
+import { AdaptiveRiskAddresses } from "./fixtures";
+import { DecisionSnapshot, readDecisions } from "./beats";
+
+// The decision ledger, read job-free. Beat 2 proves the gate is not merely a
+// blocker (a clean case flows through it to a written decision); beat 3 uses
+// the same panel to prove the opposite — the refused applicant is absent.
+export function DecisionsPanel({
+  venue,
+  addresses,
+  refreshToken,
+  absenceOf,
+}: {
+  venue: Venue | null;
+  addresses: AdaptiveRiskAddresses;
+  refreshToken: number;
+  /** When set, call out that this applicant has NO decision record. */
+  absenceOf?: string;
+}) {
+  const [snapshot, setSnapshot] = useState<DecisionSnapshot | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!venue) return;
+    setLoading(true);
+    try {
+      setSnapshot(await readDecisions(venue, addresses));
+    } catch (err) {
+      notifyError("Unable to read the decision ledger", err, venue.baseUrl);
+    } finally {
+      setLoading(false);
+    }
+  }, [venue, addresses]);
+
+  useEffect(() => {
+    if (refreshToken > 0) void refresh();
+  }, [refreshToken, refresh]);
+
+  if (!snapshot) return null;
+
+  const missing = absenceOf && !snapshot.applicants.includes(absenceOf);
+
+  return (
+    <div className="rounded border p-3 flex flex-col gap-2" data-testid="ar-decisions">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium">
+          Decision ledger{" "}
+          <span className="text-muted-foreground font-normal">
+            ({snapshot.applicants.length} decision
+            {snapshot.applicants.length === 1 ? "" : "s"})
+          </span>
+        </p>
+        <Button variant="ghost" size="sm" onClick={refresh} disabled={loading || !venue}>
+          <RefreshCw className={loading ? "size-4 animate-spin" : "size-4"} />
+        </Button>
+      </div>
+      {snapshot.records.map((entry) => (
+        <pre
+          key={entry.applicant}
+          data-testid={`ar-decision-${entry.applicant}`}
+          className="text-xs whitespace-pre-wrap break-all bg-muted rounded p-2"
+        >
+          {JSON.stringify(entry.record)}
+        </pre>
+      ))}
+      {snapshot.applicants.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          Empty — no decision has been written.
+        </p>
+      )}
+      {absenceOf && (
+        <p
+          className={missing ? "text-xs text-destructive" : "text-xs text-muted-foreground"}
+          data-testid="ar-decisions-absence"
+        >
+          {missing
+            ? `No decision record exists for ${absenceOf} — the write never happened.`
+            : `A decision record exists for ${absenceOf}.`}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/adaptive-risk/EscalationPanel.tsx
+++ b/src/components/adaptive-risk/EscalationPanel.tsx
@@ -156,9 +156,9 @@ export function EscalationPanel({
         )}
       </div>
       <p className="text-xs text-muted-foreground">
-        Approve as the risk officer: tick the approval, echo the offered grant,
-        and type a rationale. Then come back and refresh above — the parked job
-        resumes on its own.
+        Approve as the risk officer: review the requested capability, sign it
+        with your own device key, and add a rationale. Then come back and
+        refresh above — the parked job resumes on its own.
       </p>
 
       {grant && (
@@ -168,13 +168,15 @@ export function EscalationPanel({
         >
           <p className="text-sm font-medium flex items-center gap-2">
             <ShieldCheck className="size-4 text-primary" aria-hidden="true" />
-            Venue-signed grant
+            Self-signed grant
             <Badge variant={grant.valid ? "default" : "destructive"}>
               {grant.valid ? "verified" : (grant.reason ?? "invalid")}
             </Badge>
           </p>
           <p className="text-xs text-muted-foreground">
-            Checked with the venue&apos;s own <span className="font-mono">ucan:verify</span>
+            You signed this with your own device key — the venue transports and
+            verifies it but never holds the authority. Checked with the
+            venue&apos;s own <span className="font-mono">ucan:verify</span>
             {grant.issuer ? <> · issued by <span className="font-mono break-all">{grant.issuer}</span></> : null}
           </p>
           {grant.expiresAt && (

--- a/src/components/adaptive-risk/EscalationPanel.tsx
+++ b/src/components/adaptive-risk/EscalationPanel.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import type { Venue } from "@covia/covia-sdk";
+import { ExternalLink, Inbox, RefreshCw, ShieldCheck } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { StatusBadge } from "@/components/StatusBadge";
+import { notifyError } from "@/lib/notify";
+import {
+  GrantVerification,
+  extractGrantToken,
+  findOpenAsk,
+  verifyGrantToken,
+} from "./beats";
+import type { BeatJobState } from "./BeatCard";
+
+// Beat 4's surface. The approval itself happens in the REAL Inbox — this
+// panel deep-links there and never rebuilds an approval form. On return it
+// re-reads the parked job and, if the human approved, verifies the minted
+// token with the venue's own ucan:verify so the grant on screen is
+// cryptographically checked rather than merely displayed.
+
+export function EscalationPanel({
+  venue,
+  state,
+  analysis,
+  escalation,
+}: {
+  venue: Venue | null;
+  state: BeatJobState | null;
+  /** The monitor's own analysis job — real, and separate from the ask. */
+  analysis: BeatJobState | null;
+  /** Persisted ids, so the panel survives the trip to the Inbox and back. */
+  escalation: { analysisJobId: string | null; askJobId: string } | null;
+}) {
+  const [ask, setAsk] = useState<{ id: string; title: string } | null>(null);
+  const [job, setJob] = useState<BeatJobState | null>(state);
+  const [hydrated, setHydrated] = useState(false);
+  const [grant, setGrant] = useState<GrantVerification | null>(null);
+  const [checking, setChecking] = useState(false);
+
+  useEffect(() => {
+    if (state) setJob(state);
+  }, [state]);
+
+  // Re-read the parked job from the venue on mount. Beat 4 deliberately sends
+  // the viewer to the Inbox and back, and a client-side navigation drops React
+  // state — without this the panel would vanish and the ask would look lost
+  // even though it is sitting on the venue in INPUT_REQUIRED.
+  useEffect(() => {
+    if (!venue || state || hydrated || !escalation) return;
+    setHydrated(true);
+    venue.jobs
+      .get(escalation.askJobId)
+      .then((parked) =>
+        setJob({
+          jobId: parked.id,
+          status: parked.metadata?.status ?? null,
+          error: parked.metadata?.error ?? null,
+          output: parked.isComplete ? parked.output : null,
+        }),
+      )
+      .catch(() => undefined);
+  }, [venue, state, hydrated, escalation]);
+
+  // Find the ask this run raised, so the deep link lands on it rather than
+  // dumping the viewer at the top of a list.
+  useEffect(() => {
+    if (!venue || !job) return;
+    let active = true;
+    findOpenAsk(venue)
+      .then((found) => active && setAsk(found))
+      .catch(() => undefined);
+    return () => {
+      active = false;
+    };
+  }, [venue, job]);
+
+  const check = useCallback(async () => {
+    if (!venue || !job?.jobId) return;
+    setChecking(true);
+    try {
+      const refreshed = await venue.jobs.get(job.jobId);
+      const next: BeatJobState = {
+        jobId: refreshed.id,
+        status: refreshed.metadata?.status ?? null,
+        error: refreshed.metadata?.error ?? null,
+        output: refreshed.isComplete ? refreshed.output : null,
+      };
+      setJob(next);
+      const token = extractGrantToken(next.output);
+      setGrant(token ? await verifyGrantToken(venue, token) : null);
+    } catch (err) {
+      notifyError("Unable to re-read the parked job", err, venue.baseUrl);
+    } finally {
+      setChecking(false);
+    }
+  }, [venue, job?.jobId]);
+
+  if (!job) return null;
+
+  const parked = job?.status === "INPUT_REQUIRED";
+
+  return (
+    <div className="rounded border p-3 flex flex-col gap-3" data-testid="ar-escalation">
+      {analysis && (
+        <p className="text-xs text-muted-foreground" data-testid="ar-analysis-note">
+          The monitor evaluated the threshold itself, under its own capped
+          authority (job{" "}
+          <span className="font-mono">{analysis.jobId}</span>,{" "}
+          {analysis.status}). The ask below was raised by this page carrying
+          the monitor&apos;s finding verbatim — agents cannot raise HITL asks on
+          this venue build, because every agent tool call is dispatched
+          internally and the venue requires this operation to carry its own
+          job (covia-ai/covia#316).
+        </p>
+      )}
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm font-medium flex items-center gap-2">
+          <Inbox className="size-4 text-primary" aria-hidden="true" />
+          The ask is waiting for a human
+        </p>
+        <div className="flex items-center gap-2">
+          <StatusBadge status={job?.status ?? undefined} kind="job" as="pill" />
+          <Button variant="ghost" size="sm" onClick={check} disabled={checking || !venue}>
+            <RefreshCw className={checking ? "size-4 animate-spin" : "size-4"} />
+          </Button>
+        </div>
+      </div>
+
+      {parked && (
+        <p className="text-xs text-muted-foreground" data-testid="ar-parked">
+          The monitor&apos;s job is parked in{" "}
+          <span className="font-mono">INPUT_REQUIRED</span>. Nothing moves until a
+          person decides — and the agent cannot decide for itself: the venue
+          refuses an agent answering a HITL ask on{" "}
+          <span className="font-medium text-foreground">identity</span>, not on
+          scope, because approving one issues a capability grant.
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Link
+          href={ask ? `/inbox?requestId=${encodeURIComponent(ask.id)}` : "/inbox"}
+          data-testid="ar-inbox-link"
+          className="inline-flex items-center gap-1 text-sm underline underline-offset-2"
+        >
+          Answer it in your Inbox <ExternalLink className="size-3" />
+        </Link>
+        {ask && (
+          <Badge variant="outline" className="font-mono text-[11px]">
+            {ask.id}
+          </Badge>
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Approve as the risk officer: tick the approval, echo the offered grant,
+        and type a rationale. Then come back and refresh above — the parked job
+        resumes on its own.
+      </p>
+
+      {grant && (
+        <div
+          className="rounded border p-2 flex flex-col gap-1"
+          data-testid="ar-grant"
+        >
+          <p className="text-sm font-medium flex items-center gap-2">
+            <ShieldCheck className="size-4 text-primary" aria-hidden="true" />
+            Venue-signed grant
+            <Badge variant={grant.valid ? "default" : "destructive"}>
+              {grant.valid ? "verified" : (grant.reason ?? "invalid")}
+            </Badge>
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Checked with the venue&apos;s own <span className="font-mono">ucan:verify</span>
+            {grant.issuer ? <> · issued by <span className="font-mono break-all">{grant.issuer}</span></> : null}
+          </p>
+          {grant.expiresAt && (
+            <p className="text-xs" data-testid="ar-grant-expiry">
+              Expires {new Date(grant.expiresAt * 1000).toLocaleString()} — the
+              authority lapses on its own.
+            </p>
+          )}
+          {grant.attenuations.map((cap, index) => (
+            <p key={index} className="text-xs font-mono break-all">
+              {cap.can} on {cap.with}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {job?.status === "COMPLETE" && !grant && (
+        <p className="text-xs text-muted-foreground" data-testid="ar-grant-none">
+          The job resumed, but carried no capability token — the approval was
+          answered without echoing the offered grant, or it was rejected.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/adaptive-risk/EscalationPanel.tsx
+++ b/src/components/adaptive-risk/EscalationPanel.tsx
@@ -193,6 +193,20 @@ export function EscalationPanel({
         </div>
       )}
 
+      {job?.status === "COMPLETE" && job.output != null && (
+        <details className="text-xs">
+          <summary className="cursor-pointer text-muted-foreground">
+            What the resumed job returned
+          </summary>
+          <pre
+            data-testid="ar-resumed-output"
+            className="mt-1 whitespace-pre-wrap break-all bg-muted rounded p-2 max-h-56 overflow-y-auto"
+          >
+            {JSON.stringify(job.output, null, 2)}
+          </pre>
+        </details>
+      )}
+
       {job?.status === "COMPLETE" && !grant && (
         <p className="text-xs text-muted-foreground" data-testid="ar-grant-none">
           The job resumed, but carried no capability token — the approval was

--- a/src/components/adaptive-risk/LedgerPanel.tsx
+++ b/src/components/adaptive-risk/LedgerPanel.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { Venue } from "@covia/covia-sdk";
+import { RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { notifyError } from "@/lib/notify";
+import { AdaptiveRiskAddresses } from "./fixtures";
+import { LedgerSnapshot, readLedger } from "./beats";
+
+// The shared signal ledger, read job-free off the lattice (workspace.list /
+// read — no job minted by looking). This is the beat-1 effect: the fraud
+// agent wrote here, and the credit agent will read from here, without either
+// knowing the other exists.
+export function LedgerPanel({
+  venue,
+  addresses,
+  refreshToken,
+}: {
+  venue: Venue | null;
+  addresses: AdaptiveRiskAddresses;
+  refreshToken: number;
+}) {
+  const [snapshot, setSnapshot] = useState<LedgerSnapshot | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!venue) return;
+    setLoading(true);
+    try {
+      setSnapshot(await readLedger(venue, addresses));
+    } catch (err) {
+      notifyError("Unable to read the signal ledger", err, venue.baseUrl);
+    } finally {
+      setLoading(false);
+    }
+  }, [venue, addresses]);
+
+  useEffect(() => {
+    if (refreshToken > 0) void refresh();
+  }, [refreshToken, refresh]);
+
+  if (!snapshot) return null;
+
+  return (
+    <div className="rounded border p-3 flex flex-col gap-2" data-testid="ar-ledger">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium">
+          Signal ledger{" "}
+          <span className="text-muted-foreground font-normal">
+            ({snapshot.signalCount} signal record{snapshot.signalCount === 1 ? "" : "s"},{" "}
+            {snapshot.flags.length} flagged device{snapshot.flags.length === 1 ? "" : "s"})
+          </span>
+        </p>
+        <Button variant="ghost" size="sm" onClick={refresh} disabled={loading || !venue}>
+          <RefreshCw className={loading ? "size-4 animate-spin" : "size-4"} />
+        </Button>
+      </div>
+      {snapshot.signalCount > 0 && (
+        <p className="text-xs text-muted-foreground font-mono break-all">
+          {snapshot.signalKeys.join(" · ")}
+        </p>
+      )}
+      {snapshot.flags.map((flag) => (
+        <pre
+          key={flag.device}
+          data-testid={`ar-flag-${flag.device}`}
+          className="text-xs whitespace-pre-wrap break-all bg-muted rounded p-2"
+        >
+          {`${flag.device}: ${JSON.stringify(flag.record)}`}
+        </pre>
+      ))}
+      {snapshot.signalCount === 0 && snapshot.flags.length === 0 && (
+        <p className="text-xs text-muted-foreground">Empty — run the beat above.</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/adaptive-risk/PolicyLinks.tsx
+++ b/src/components/adaptive-risk/PolicyLinks.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+import type { Venue } from "@covia/covia-sdk";
+import { ExternalLink, Scale } from "lucide-react";
+import { AdaptiveRiskAddresses } from "./fixtures";
+
+// The policy that refused the invocation is not hidden inside the runtime:
+// it is an ordinary operation with its own record on the venue. Link to both
+// the gate and the content-addressed policy it runs, so a viewer can read the
+// rule that stopped the write.
+//
+// The operations route takes a namespace-explicit address as path segments
+// (`w/ops/…`, `a/<hash>`), so addresses are passed through unencoded per
+// segment — see venues/[slug]/operations/[...id].
+export function PolicyLinks({
+  venue,
+  addresses,
+}: {
+  venue: Venue | null;
+  addresses: AdaptiveRiskAddresses;
+}) {
+  if (!venue) return null;
+  const base = `/venues/${encodeURIComponent(venue.venueId)}/operations`;
+  const opHref = (address: string) =>
+    `${base}/${address.split("/").map(encodeURIComponent).join("/")}`;
+
+  const policyAddress = addresses.policyAsset
+    ? `a/${addresses.policyAsset}`
+    : null;
+
+  return (
+    <div className="rounded border p-3 flex flex-col gap-1" data-testid="ar-policy-links">
+      <p className="text-sm font-medium flex items-center gap-2">
+        <Scale className="size-4 text-primary" aria-hidden="true" />
+        The rule that refused it
+      </p>
+      <p className="text-xs text-muted-foreground">
+        The gate is an ordinary operation, and the policy it applies is
+        content-addressed — both have their own records on this venue.
+      </p>
+      <Link
+        href={opHref(addresses.limitGate)}
+        data-testid="ar-gate-link"
+        className="text-xs font-mono underline underline-offset-2 inline-flex items-center gap-1"
+      >
+        {addresses.limitGate} <ExternalLink className="size-3" />
+      </Link>
+      {policyAddress && (
+        <Link
+          href={opHref(policyAddress)}
+          data-testid="ar-policy-link"
+          className="text-xs font-mono underline underline-offset-2 inline-flex items-center gap-1 break-all"
+        >
+          {policyAddress} <ExternalLink className="size-3" />
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/src/components/adaptive-risk/README.md
+++ b/src/components/adaptive-risk/README.md
@@ -1,0 +1,121 @@
+# Adaptive Risk demo
+
+A guided walkthrough, inside the Covia app, of three agents and one policy
+gate. Fictional issuer **Meridian Bank Singapore**, thin-file starter card,
+base limit **S$500**, twelve synthetic applicants.
+
+It runs on whatever venue you have selected, using operations you register
+yourself from the page. Every beat is a real job on that venue; a failure is
+shown as a failure, with the venue's own error string.
+
+> **All data here is synthetic.** Twelve applicants, one fictional bank.
+> Nothing describes a real person, device or lender. The page carries a
+> permanent panel stating exactly what is real and what is not — read it
+> before showing this to anyone.
+
+## The claim it makes
+
+The credit agent cannot issue a limit unless the fraud agent's signals pass a
+policy gate. Credit and fraud are not integrated by a model; they are joined
+at the execution layer, and the join is enforced by the runtime.
+
+| Entity | Role | Authority (`config.caps`) |
+|---|---|---|
+| `rk-sentinel` | fraud signals | read applications; write signals and flags |
+| `rk-assessor` | credit decisions | read applications + signals; write decisions; **invoke `issue-limit` gated by the limit gate** |
+| `rk-monitor` | drift watch | read signals and cohort windows; invoke `hitl:request` |
+| limit gate | the policy itself, as an ordinary content-addressed operation | — |
+
+Only the assessor holds any grant to `issue-limit`, and that grant is
+conditional (`nb: { gate: … }`). The sentinel and the monitor hold none.
+
+## Run it against a local venue
+
+1. **Start a venue** (from `covia-repo`):
+
+   ```bash
+   java -jar venue/target/covia.jar dev/local.json
+   ```
+
+   For local development the config wants `users.autoCreate: true` so the app
+   can admit a fresh browser device key, and `auth.public.caps: "unrestricted"`
+   if you want anonymous seeding to work. Both are local-only settings — see
+   `venue/docs/CONFIG.md`.
+
+2. **Point the app at it.** `NEXT_PUBLIC_IS_ENV_PROD=false` in
+   `frontend/.env.local` adds `http://127.0.0.1:8080` to the venue list, then
+   pick it in the top-right venue selector.
+
+3. **Sign in.** Seeding writes into *your* namespace and the Inbox beat needs
+   you to answer as yourself, so the demo requires a signed-in identity — a
+   generated device key is enough.
+
+4. **Add an LLM key.** The agents call a provider through the venue. Add your
+   key under **Secrets** with the name the provider expects (default:
+   `OPENAI_API_KEY` for `v/ops/langchain/openai`). The key is stored in the
+   venue's per-user encrypted secret store, under your DID.
+
+5. **Run setup**, then the beats in order.
+
+Any venue works, not just a local one — the only requirement is an identity
+that venue admits. The public Covia venues do not auto-create users, so ask
+an operator to admit your DID first.
+
+## Swap in your own operations
+
+Every address is editable in the setup panel **before** anything is
+registered, and your edits are persisted per browser:
+
+| Field | What it is |
+|---|---|
+| Data root | `w/risk` — applications, signals, flags, decisions, windows live under it |
+| Limit gate operation | the gate the assessor's grant is conditional on |
+| Issue-limit operation | the decision-writing operation |
+| Policy operation | content-addressed; left empty, setup registers ours and fills in the hash |
+| Agent ids | `rk-sentinel`, `rk-assessor`, `rk-monitor` |
+| LLM provider operation / Model | e.g. `v/ops/langchain/openai`; empty model = provider default |
+
+Point any of them at something you already run and setup will use yours
+instead of registering its own. Setup checks each address before writing, so
+re-running is a no-op rather than a duplicate.
+
+### How the policy is expressed
+
+The policy operation's **output schema is the policy**:
+
+```jsonc
+{ "amount": { "type": "number", "maximum": 500 },
+  "deviceFlagged": { "const": false } }
+```
+
+The gate is a `strict` orchestrator operation that reads the device-flag
+ledger, composes a verdict, and pipes it through that policy operation. A
+verdict that violates the schema fails the step, which fails the gate, which
+denies the invocation — all venue-side. To change the policy, register your
+own operation with a different output schema and put its address in the
+setup panel.
+
+## Tear down
+
+The **Tear down** button removes what setup created on this venue: the data
+subtree (`w/risk`), the gate and issue-limit operation addresses, and the
+three agents.
+
+Two things deliberately survive:
+
+- **Job records.** They are the audit trail — the point of the demo.
+- **The content-addressed policy asset.** Assets are immutable and there is no
+  asset-delete in the SDK. It remains on the venue, unreferenced and inert.
+
+## Development notes
+
+- Reads are job-free (`workspace.read` / `list`); only user-driven actions
+  invoke. See `AGENTS.md` — a non-user-driven `invoke` is a defect.
+- Beat failures render `jobData.error` verbatim, deliberately **not** through
+  `friendlyError()`, which rewrites denials to "Access denied" and would
+  destroy the point of beat 3.
+- A failed transition suspends an agent by design; beats clear that on the
+  Run click, which is the operator's decision to retry.
+- Narration lives in `story.ts` as data. Per `JOBS.md`, recovery *stabilises
+  and never re-executes* — this demo says **reconstruct**, and a test asserts
+  the word "replay" appears nowhere.

--- a/src/components/adaptive-risk/README.md
+++ b/src/components/adaptive-risk/README.md
@@ -29,6 +29,39 @@ at the execution layer, and the join is enforced by the runtime.
 Only the assessor holds any grant to `issue-limit`, and that grant is
 conditional (`nb: { gate: … }`). The sentinel and the monitor hold none.
 
+## The five beats
+
+| # | Beat | What is real |
+|---|---|---|
+| 1 | Two silos, one substrate | `rk-sentinel` reads the applications and writes signals + device flags under its own capped authority. It never contacts the credit agent. |
+| 2 | A clean approval | `rk-assessor` reads both sources and issues S$500 for a clean applicant. The gate evaluates and passes; a decision is written. |
+| 3 | The refusal | Same agent, same capabilities, S$2,500 on a flagged device. The gate denies before execution and the venue's own denial string is shown verbatim. No decision is written. |
+| 4 | Drift becomes a governed event | Fixture swaps to week two; the monitor evaluates the breach; a HITL ask parks in `INPUT_REQUIRED`; you answer in the real Inbox and sign a capability with your own key; the parked job resumes and the token is verified. |
+| 5 | Reconstruction | The APP-1071 refusal read back over plain REST — inputs, caller, error, and the `prev` chain — with a curl that works in your terminal. |
+
+Beats 2 and 3 share one runner deliberately: nothing about the agent changes
+between the approval and the refusal, only what it is asked to issue. **Beat 2
+alone does not prove the gate is live — the pair does.**
+
+### Two places the runtime differs from the obvious story
+
+Both are stated on the page itself, not just here.
+
+**Beat 4's ask is raised by the page, not by the agent.** Every agent tool call
+is dispatched internally, and the venue requires `hitl:request` to carry its own
+job, so an agent cannot raise one at all on this build
+([covia#316](https://github.com/covia-ai/covia/issues/316)). The monitor's
+*analysis* is real and its finding is carried into the ask verbatim.
+
+**Beat 4's grant is signed by you, not minted by the venue.** A device-key
+sign-in is self-sovereign, so the venue refuses to root-sign a grant over your
+own namespace — it says so plainly. The demo uses a COG-19 `token` ask instead:
+you sign the capability with your own key and the venue only transports and
+verifies it. The lifetime is 7 days (venue-capped), and the grant confers write
+on the reviewed-limit record — deliberately **not** invoke on `issue-limit`,
+since an ungated covering grant would short-circuit the gate that beats 2 and 3
+exist to demonstrate.
+
 ## Run it against a local venue
 
 1. **Start a venue** (from `covia-repo`):
@@ -55,7 +88,8 @@ conditional (`nb: { gate: … }`). The sentinel and the monitor hold none.
    `OPENAI_API_KEY` for `v/ops/langchain/openai`). The key is stored in the
    venue's per-user encrypted secret store, under your DID.
 
-5. **Run setup**, then the beats in order.
+5. **Run setup**, then the beats in order. Beat 4 stops and waits for you in
+   the Inbox — that pause is the point, not a hang.
 
 Any venue works, not just a local one — the only requirement is an identity
 that venue admits. The public Covia venues do not auto-create users, so ask
@@ -119,3 +153,13 @@ Two things deliberately survive:
 - Narration lives in `story.ts` as data. Per `JOBS.md`, recovery *stabilises
   and never re-executes* — this demo says **reconstruct**, and a test asserts
   the word "replay" appears nowhere.
+- Beat 5's curl carries a short-lived identity token signed in the browser,
+  because job records are per-caller and an anonymous read 404s. It is a
+  credential: it lasts ten minutes and is never transmitted by the page.
+- A capped agent needs `crud/read` on a tool's *definition* as well as `invoke`
+  on the operation; without it the tool is silently dropped and the model may
+  report an action it never performed
+  ([covia#317](https://github.com/covia-ai/covia/issues/317)). That is why the
+  agents hold read on the demo's operation namespace.
+- If a beat reports that the gate did not refuse, believe it. The panels are
+  written to say what happened rather than what the script expects.

--- a/src/components/adaptive-risk/ReconstructionPanel.tsx
+++ b/src/components/adaptive-risk/ReconstructionPanel.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { Venue } from "@covia/covia-sdk";
+import { Copy, FileSearch, RefreshCw } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DidDisplay } from "@/components/DidDisplay";
+import { useAuthStore } from "@/hooks/use-auth";
+import { notifyError, notifySuccess } from "@/lib/notify";
+import {
+  JOBS_MD_RULE,
+  RecordSummary,
+  reconstructionCurl,
+  signIdentityToken,
+  summariseRecord,
+} from "./beats";
+
+// Beat 5. The same record, read back over plain REST — not a re-run.
+//
+// A job record lives in its caller's own namespace, so an anonymous GET 404s.
+// The curl therefore carries a short-lived identity token, signed here in the
+// browser with the user's own device key and never sent anywhere by this page.
+// Without that the "paste it into your terminal" claim would simply be false.
+
+export function ReconstructionPanel({
+  venue,
+  jobId,
+  label,
+}: {
+  venue: Venue | null;
+  /** The job to reconstruct — beat 3's refusal. */
+  jobId: string | null;
+  label: string;
+}) {
+  const credential = useAuthStore((state) =>
+    venue ? state.authMap[venue.venueId] ?? null : null,
+  );
+  const signingKeyHex =
+    credential?.type === "keypair" ? credential.privateKeyHex : null;
+
+  const [record, setRecord] = useState<unknown>(null);
+  const [summary, setSummary] = useState<RecordSummary | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!venue || !jobId) return;
+    setLoading(true);
+    try {
+      const job = await venue.jobs.get(jobId);
+      setRecord(job.metadata);
+      setSummary(summariseRecord(job.metadata));
+      setToken(
+        signingKeyHex ? signIdentityToken(signingKeyHex, venue.venueId) : null,
+      );
+    } catch (err) {
+      notifyError("Unable to read the job record", err, venue.baseUrl);
+    } finally {
+      setLoading(false);
+    }
+  }, [venue, jobId, signingKeyHex]);
+
+  const curl = venue ? reconstructionCurl(venue.baseUrl, jobId ?? "<job-id>", token) : "";
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(curl);
+      notifySuccess("Copied", { description: "Paste it into a terminal." });
+    } catch (err) {
+      notifyError("Unable to copy the command", err);
+    }
+  };
+
+  if (!jobId) {
+    return (
+      <p className="text-xs text-muted-foreground" data-testid="ar-reconstruct-none">
+        Run beat 3 first — reconstruction reads back the refusal it recorded.
+      </p>
+    );
+  }
+
+  return (
+    <div className="rounded border p-3 flex flex-col gap-3" data-testid="ar-reconstruct">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm font-medium flex items-center gap-2">
+          <FileSearch className="size-4 text-primary" aria-hidden="true" />
+          Reconstruct {label}
+        </p>
+        <Button variant="outline" size="sm" onClick={load} disabled={loading || !venue}>
+          <RefreshCw className={loading ? "size-4 animate-spin" : "size-4"} />
+          Read the record
+        </Button>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        {JOBS_MD_RULE} Nothing below runs the decision again — it reads the
+        record the venue already holds.
+      </p>
+
+      {summary && (
+        <div className="flex flex-col gap-1 text-xs" data-testid="ar-record-summary">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline">{summary.status ?? "unknown"}</Badge>
+            <span className="text-muted-foreground">
+              {summary.prevDepth} predecessor state
+              {summary.prevDepth === 1 ? "" : "s"} on the record
+            </span>
+          </div>
+          {summary.states.length > 0 && (
+            <p className="font-mono" data-testid="ar-record-states">
+              {summary.states.join(" → ")}
+            </p>
+          )}
+          {summary.caller && (
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground">caller</span>
+              <DidDisplay value={summary.caller} />
+            </div>
+          )}
+          {summary.actor ? (
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground">actor</span>
+              <DidDisplay value={summary.actor} />
+            </div>
+          ) : (
+            <p className="text-muted-foreground" data-testid="ar-no-actor">
+              No <span className="font-mono">actor</span> field — it appears only
+              when the acting principal differs from the record&apos;s owner.
+            </p>
+          )}
+          {summary.error && (
+            <pre className="whitespace-pre-wrap break-all bg-muted rounded p-2">
+              {summary.error}
+            </pre>
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs font-medium">The same record, over plain REST</p>
+          <Button variant="ghost" size="sm" onClick={copy} disabled={!venue}>
+            <Copy className="size-4" /> Copy
+          </Button>
+        </div>
+        <pre
+          data-testid="ar-curl"
+          className="text-xs whitespace-pre-wrap break-all bg-muted rounded p-3"
+        >
+          {curl}
+        </pre>
+        {token ? (
+          <p className="text-[11px] text-muted-foreground">
+            Job records live in their caller&apos;s namespace, so this read carries
+            your identity. The token above was signed here with your device key,
+            lasts ten minutes, and is never sent anywhere by this page — treat it
+            like a password until it lapses.
+          </p>
+        ) : (
+          <p className="text-[11px] text-muted-foreground" data-testid="ar-curl-no-token">
+            Signed in without a device key, so no token can be minted here. Supply
+            your own identity token as <span className="font-mono">COVIA_TOKEN</span>.
+          </p>
+        )}
+      </div>
+
+      {record != null && (
+        <details className="text-xs">
+          <summary className="cursor-pointer text-muted-foreground">
+            The record this page read (compare it with the curl output)
+          </summary>
+          <pre
+            data-testid="ar-record-raw"
+            className="mt-1 whitespace-pre-wrap break-all bg-muted rounded p-2 max-h-72 overflow-y-auto"
+          >
+            {JSON.stringify(record, null, 2)}
+          </pre>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/src/components/adaptive-risk/RefusalPanel.tsx
+++ b/src/components/adaptive-risk/RefusalPanel.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { ShieldX } from "lucide-react";
+import type { BeatJobState } from "./BeatCard";
+
+// Beat 3 has two levels, and glossing over that would be dishonest:
+//
+//   inner  — the assessor's invoke of issue-limit, DENIED by the gate before
+//            execution. The denial is the venue's own string and the write
+//            never happened.
+//   outer  — the agent:request job, which COMPLETEs, because the agent did
+//            what it was asked: it reported the refusal verbatim and stopped.
+//
+// So the beat card's badge reads COMPLETE while the thing being demonstrated
+// is a refusal. This panel names that explicitly and shows the denial itself,
+// rather than letting a green badge imply the write succeeded.
+
+const DENIAL_MARKER = "Capability denied";
+
+/**
+ * The venue's denial string, wherever it surfaced — never reworded.
+ *
+ * Depth varies: an agent reporting a refused tool call nests it inside its
+ * own task envelope (`output.output.error`), while a directly-denied invoke
+ * puts it on the job's `error`. Scan rather than assume a shape, so a change
+ * to the envelope degrades to "no denial found" rather than a wrong claim.
+ */
+function findMarked(value: unknown, depth = 0): string | null {
+  if (depth > 6) return null;
+  if (typeof value === "string") {
+    return value.includes(DENIAL_MARKER) ? value : null;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const hit = findMarked(item, depth + 1);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  if (value && typeof value === "object") {
+    for (const nested of Object.values(value as Record<string, unknown>)) {
+      const hit = findMarked(nested, depth + 1);
+      if (hit) return hit;
+    }
+  }
+  return null;
+}
+
+export function extractDenial(state: BeatJobState | null): string | null {
+  if (!state) return null;
+  return findMarked(state.error) ?? findMarked(state.output);
+}
+
+export function RefusalPanel({ state }: { state: BeatJobState | null }) {
+  const denial = extractDenial(state);
+  if (!state) return null;
+
+  if (!denial) {
+    // The gate did not refuse. Say so plainly instead of implying it did.
+    return (
+      <p className="text-xs text-muted-foreground" data-testid="ar-refusal-none">
+        No capability denial in this run — the gate did not refuse. Check the
+        job record above.
+      </p>
+    );
+  }
+
+  return (
+    <div
+      className="rounded border border-destructive/60 bg-destructive/5 p-3 flex flex-col gap-2"
+      data-testid="ar-refusal"
+    >
+      <p className="text-sm font-medium flex items-center gap-2">
+        <ShieldX className="size-4 text-destructive" aria-hidden="true" />
+        The write was refused by the runtime
+      </p>
+      <pre
+        data-testid="ar-refusal-denial"
+        className="text-xs whitespace-pre-wrap break-all bg-muted rounded p-2"
+      >
+        {denial}
+      </pre>
+      <p className="text-xs text-muted-foreground">
+        The model was not persuaded not to write — it was not permitted to. The
+        gate ran <span className="font-medium text-foreground">before</span>{" "}
+        issue-limit executed, read the shared signal ledger, and denied the
+        invocation.
+      </p>
+      <p className="text-xs text-muted-foreground">
+        The agent&apos;s own job above reads COMPLETE because the agent did what it
+        was asked: it reported the refusal word for word and stopped. The
+        invocation it attempted is the thing that failed, and the decision
+        ledger below shows the write never happened.
+      </p>
+    </div>
+  );
+}

--- a/src/components/adaptive-risk/SetupPanel.tsx
+++ b/src/components/adaptive-risk/SetupPanel.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import type { Venue } from "@covia/covia-sdk";
+import { Hammer, RotateCcw, Trash2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Spinner } from "@/components/ui/shadcn-io/spinner";
+import { notifyError, notifySuccess } from "@/lib/notify";
+import {
+  SeedItemResult,
+  useAdaptiveRiskConfig,
+} from "@/hooks/use-adaptive-risk-config";
+import { AdaptiveRiskAddresses } from "./fixtures";
+import { seedAdaptiveRisk, teardownAdaptiveRisk } from "./seed";
+
+// The seeding step: every address is on the table, editable, BEFORE anything
+// is registered — a user can point the whole demo at operations they already
+// run. Results list exactly what was created, with addresses, and failures
+// carry the venue's own error string verbatim.
+
+const ADDRESS_FIELDS: Array<{
+  key: keyof AdaptiveRiskAddresses;
+  label: string;
+  hint?: string;
+}> = [
+  { key: "root", label: "Data root", hint: "applications, signals, flags, decisions, windows live under here" },
+  { key: "limitGate", label: "Limit gate operation" },
+  { key: "issueLimit", label: "Issue-limit operation" },
+  {
+    key: "policyAsset",
+    label: "Policy operation (content-addressed)",
+    hint: "left empty, seeding registers the starter-card policy and fills this in — or paste your own",
+  },
+  { key: "sentinelAgent", label: "Fraud agent id" },
+  { key: "assessorAgent", label: "Credit agent id" },
+  { key: "monitorAgent", label: "Drift monitor agent id" },
+  { key: "llmOperation", label: "LLM provider operation", hint: "the venue needs this provider's API key in Secrets" },
+  { key: "model", label: "Model", hint: "empty = provider default" },
+];
+
+export function SetupPanel({
+  venue,
+  isAuthenticated,
+}: {
+  venue: Venue | null;
+  isAuthenticated: boolean;
+}) {
+  const { addresses, reports, setAddresses, resetAddresses, setReport } =
+    useAdaptiveRiskConfig();
+  const [running, setRunning] = useState<"seed" | "teardown" | null>(null);
+  const [liveItems, setLiveItems] = useState<SeedItemResult[] | null>(null);
+
+  const report = venue ? reports[venue.venueId] : undefined;
+  const items = liveItems ?? report?.items ?? null;
+  const canRun = !!venue && isAuthenticated && !running;
+
+  const runSeed = async () => {
+    if (!venue) return;
+    setRunning("seed");
+    setLiveItems([]);
+    try {
+      const outcome = await seedAdaptiveRisk(venue, addresses, (item) =>
+        setLiveItems((prev) => [...(prev ?? []), item]),
+      );
+      setReport(venue.venueId, outcome.report);
+      if (outcome.ok) {
+        if (outcome.policyRef && outcome.policyRef !== addresses.policyAsset) {
+          setAddresses({ policyAsset: outcome.policyRef });
+        }
+        notifySuccess("Demo seeded", {
+          description: `${outcome.report.items.filter((i) => i.status === "created").length} created, ${outcome.report.items.filter((i) => i.status === "existing").length} already present.`,
+        });
+      } else {
+        notifyError("Unable to seed the demo", new Error(outcome.report.items.at(-1)?.error ?? "seed failed"), venue.baseUrl);
+      }
+    } catch (err) {
+      notifyError("Unable to seed the demo", err, venue.baseUrl);
+    } finally {
+      setLiveItems(null);
+      setRunning(null);
+    }
+  };
+
+  const runTeardown = async () => {
+    if (!venue) return;
+    setRunning("teardown");
+    try {
+      const result = await teardownAdaptiveRisk(venue, addresses);
+      setLiveItems(result.items);
+      if (result.ok) {
+        setReport(venue.venueId, null);
+        notifySuccess("Demo torn down", {
+          description:
+            "Named paths and agents removed. The content-addressed policy asset is immutable and remains, inert.",
+        });
+      } else {
+        notifyError("Unable to tear down the demo", new Error(result.items.find((i) => i.status === "failed")?.error ?? "teardown failed"), venue.baseUrl);
+      }
+    } catch (err) {
+      notifyError("Unable to tear down the demo", err, venue.baseUrl);
+    } finally {
+      setRunning(null);
+    }
+  };
+
+  return (
+    <section aria-label="Set up this demo" data-testid="ar-setup" className="flex flex-col gap-4">
+      <div>
+        <h3 className="text-base font-semibold mb-1">Set up this demo</h3>
+        <p className="text-sm text-muted-foreground">
+          Seeding registers the policy, the gate, the decision operation, twelve
+          synthetic applications, two cohort windows and three agents on the
+          selected venue — under your identity, at the addresses below. Edit any
+          address first to use operations you already run. Re-running is a
+          no-op; nothing is duplicated.
+        </p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2" data-testid="ar-setup-form">
+        {ADDRESS_FIELDS.map((field) => (
+          <div key={field.key} className="flex flex-col gap-1">
+            <Label htmlFor={`ar-addr-${field.key}`} className="text-xs">
+              {field.label}
+            </Label>
+            <Input
+              id={`ar-addr-${field.key}`}
+              data-testid={`ar-addr-${field.key}`}
+              className="font-mono text-xs"
+              value={addresses[field.key]}
+              disabled={!!running}
+              onChange={(event) => setAddresses({ [field.key]: event.target.value })}
+            />
+            {field.hint && (
+              <p className="text-[11px] text-muted-foreground">{field.hint}</p>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button data-testid="ar-setup-run" onClick={runSeed} disabled={!canRun}>
+          {running === "seed" ? <Spinner variant="ellipsis" /> : <Hammer className="size-4" />}
+          Run setup
+        </Button>
+        <Button variant="ghost" size="sm" onClick={resetAddresses} disabled={!!running}>
+          <RotateCcw className="size-4" /> Reset addresses
+        </Button>
+        {report && (
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                data-testid="ar-setup-teardown"
+                disabled={!canRun}
+              >
+                {running === "teardown" ? <Spinner variant="ellipsis" /> : <Trash2 className="size-4" />}
+                Tear down
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Tear down the demo?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Removes the demo&apos;s data subtree ({addresses.root}), the gate and
+                  issue-limit operations, and the three agents from this venue. Job
+                  records stay — they are the audit trail. The content-addressed
+                  policy asset is immutable and remains, inert.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={runTeardown}>Tear down</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        )}
+        {!isAuthenticated && (
+          <p className="text-xs text-muted-foreground">Sign in to run setup.</p>
+        )}
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        The agents call the model through{" "}
+        <code className="font-mono">{addresses.llmOperation}</code>; the venue
+        needs that provider&apos;s API key —{" "}
+        <Link href="/secrets" className="underline underline-offset-2">
+          manage Secrets
+        </Link>
+        .
+      </p>
+
+      {items && items.length > 0 && (
+        <ol className="flex flex-col gap-1" data-testid="ar-seed-items">
+          {items.map((item, index) => (
+            <li
+              key={`${item.address}-${index}`}
+              className="flex flex-col gap-1 rounded border px-3 py-1.5"
+            >
+              <div className="flex items-center justify-between gap-2 text-sm">
+                <span>{item.label}</span>
+                <span className="flex items-center gap-2 min-w-0">
+                  <code className="font-mono text-xs text-muted-foreground truncate max-w-64">
+                    {item.address}
+                  </code>
+                  <Badge
+                    variant={
+                      item.status === "failed"
+                        ? "destructive"
+                        : item.status === "created"
+                          ? "default"
+                          : "outline"
+                    }
+                  >
+                    {item.status}
+                  </Badge>
+                </span>
+              </div>
+              {item.error && (
+                <pre
+                  data-testid="ar-seed-error"
+                  className="text-xs text-destructive whitespace-pre-wrap break-all bg-muted rounded p-2"
+                >
+                  {item.error}
+                </pre>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+      {report && !running && (
+        <p className="text-xs text-muted-foreground" data-testid="ar-seed-summary">
+          Seeded on this venue {new Date(report.seededAt).toLocaleString()}. If a
+          write was refused above, the message is the venue&apos;s own — you need a
+          venue you can write to (a local one works).
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/components/adaptive-risk/beats.ts
+++ b/src/components/adaptive-risk/beats.ts
@@ -21,16 +21,26 @@ function sentinelTask(addresses: AdaptiveRiskAddresses): string {
   );
 }
 
-// A failed task leaves an agent SUSPENDED with the old failure as its
-// reason; resume is idempotent, so always clear that before dispatching —
-// otherwise every retry reports the stale error instead of trying again.
+// A failed transition suspends the agent on purpose: it accepts no new work
+// and names its cause and remedy ("fix the cause, then use agent:resume"),
+// so a broken agent cannot burn through queued tasks. Clearing that is the
+// operator's call — here the Run click IS that decision, which is why resume
+// happens per run rather than automatically in the background. Same pattern
+// as AIPrompt's dispatch path.
 async function resumeIfSuspended(venue: Venue, agentId: string): Promise<void> {
+  let suspended = false;
   try {
     const info = await venue.agents.info(agentId);
-    if (info?.status === "SUSPENDED") await venue.agents.resume(agentId);
+    suspended = info?.status === "SUSPENDED";
   } catch {
-    // Missing agent surfaces properly on the request itself.
+    // A missing or unreadable agent surfaces on the request itself, with the
+    // venue's own message — nothing useful to add here.
+    return;
   }
+  if (!suspended) return;
+  // A failed resume must not be swallowed: the request below would then fail
+  // with the stale suspension reason and hide the real cause.
+  await venue.agents.resume(agentId);
 }
 
 export async function runBeat1(
@@ -42,6 +52,44 @@ export async function runBeat1(
   return op.invoke({
     agentId: addresses.sentinelAgent,
     input: { task: sentinelTask(addresses) },
+    wait: true,
+  });
+}
+
+function assessorTask(
+  addresses: AdaptiveRiskAddresses,
+  applicant: string,
+  amount: number,
+  device: string,
+): string {
+  const paths = riskPaths(addresses.root);
+  return (
+    `Assess starter-card applicant ${applicant}. Read their application at ` +
+    `${paths.applications}/${applicant} and the fraud signal ledger under ` +
+    `${paths.signals}. Then issue the decision by invoking ${addresses.issueLimit} ` +
+    `with exactly {"applicant": "${applicant}", "amount": ${amount}, "device": "${device}"}. ` +
+    `Issue exactly that amount — the runtime enforces policy, not you. If the ` +
+    `invocation fails, report the error you received word for word and stop.`
+  );
+}
+
+/**
+ * Beats 2 and 3 are the same call with different inputs — that is the point:
+ * nothing about the assessor changes between the approval and the refusal,
+ * only what it is asked to issue. The gate decides.
+ */
+export async function runAssessorBeat(
+  venue: Venue,
+  addresses: AdaptiveRiskAddresses,
+  applicant: string,
+  amount: number,
+  device: string,
+): Promise<Job> {
+  await resumeIfSuspended(venue, addresses.assessorAgent);
+  const op = await resolveOperationByAddress(venue, AGENT_REQUEST_OP);
+  return op.invoke({
+    agentId: addresses.assessorAgent,
+    input: { task: assessorTask(addresses, applicant, amount, device) },
     wait: true,
   });
 }
@@ -70,4 +118,28 @@ export async function readLedger(
     })),
   );
   return { signalCount: signalKeys.length, signalKeys, flags };
+}
+
+// The decision ledger, read job-free. Beat 2's effect (a decision written)
+// and beat 3's non-effect (nothing written for the refused applicant) are
+// both read from here — the refusal is proved by absence.
+export type DecisionSnapshot = {
+  applicants: string[];
+  records: Array<{ applicant: string; record: unknown }>;
+};
+
+export async function readDecisions(
+  venue: Venue,
+  addresses: AdaptiveRiskAddresses,
+): Promise<DecisionSnapshot> {
+  const paths = riskPaths(addresses.root);
+  const listed = await venue.workspace.list(paths.decisions);
+  const applicants = (listed.exists ? (listed.keys ?? []) : []).map(String);
+  const records = await Promise.all(
+    applicants.map(async (applicant) => ({
+      applicant,
+      record: (await venue.workspace.read(`${paths.decisions}/${applicant}`)).value,
+    })),
+  );
+  return { applicants, records };
 }

--- a/src/components/adaptive-risk/beats.ts
+++ b/src/components/adaptive-risk/beats.ts
@@ -328,15 +328,22 @@ export async function verifyGrantToken(
   };
 }
 
-/** The UCAN the venue minted when the human approved, if the job carried one. */
+// A JWT by shape, not by key name. The venue delivers a capability token two
+// different ways: a venue-minted COG-17 grant lands on `token`, while a
+// self-signed COG-19 transported token rides `tokens` keyed by ask id
+// (HITLAdapter.resolveAnswer). Matching the shape covers both, and anything
+// else the envelope grows later.
+const JWT_SHAPE = /^[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}$/;
+
 export function extractGrantToken(output: unknown): string | null {
   const seen = new Set<unknown>();
   const walk = (value: unknown, depth: number): string | null => {
     if (depth > 6 || value == null || seen.has(value)) return null;
+    if (typeof value === "string") {
+      return JWT_SHAPE.test(value) ? value : null;
+    }
     if (typeof value === "object") {
       seen.add(value);
-      const token = (value as { token?: unknown }).token;
-      if (typeof token === "string" && token.split(".").length === 3) return token;
       for (const nested of Object.values(value as Record<string, unknown>)) {
         const hit = walk(nested, depth + 1);
         if (hit) return hit;

--- a/src/components/adaptive-risk/beats.ts
+++ b/src/components/adaptive-risk/beats.ts
@@ -1,5 +1,6 @@
 import type { Job, Venue } from "@covia/covia-sdk";
 import { resolveOperationByAddress } from "@/lib/operations-catalog";
+import { createUCANJWT, hexToPrivateKey } from "@covia/covia-sdk";
 import { AdaptiveRiskAddresses, STARTER_CARD_LIMIT, riskPaths } from "./fixtures";
 
 // Beat runners. Each beat is ONE real job on the venue: the agent:request
@@ -352,4 +353,92 @@ export function extractGrantToken(output: unknown): string | null {
     return null;
   };
   return walk(output, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Beat 5. Reconstruction, never re-execution. JOBS.md is explicit that
+// recovery "stabilises, never re-executes" — a stored record is read back, and
+// nothing is ever re-fired. So this beat produces a plain REST read of a
+// record that already exists, not a way to run anything again.
+
+export const JOBS_MD_RULE =
+  "Recovery stabilises, never re-executes — a venue restart leaves every job " +
+  "in a stable, honest state so callers can resume, cancel, or retry as they " +
+  "wish. Re-execution would double side effects for non-idempotent ops, so " +
+  "nothing is ever re-fired.";
+
+/**
+ * The curl that returns the same record from plain REST.
+ *
+ * Job records live in the caller's own namespace, so an anonymous GET 404s —
+ * the read has to carry the caller's identity. `token` is a short-lived
+ * identity UCAN signed in the browser with the user's own device key; it is
+ * never sent anywhere by this page, only rendered for the user to copy.
+ */
+export function reconstructionCurl(
+  baseUrl: string,
+  jobId: string,
+  token: string | null,
+): string {
+  const url = `${baseUrl.replace(/\/$/, "")}/api/v1/jobs/${jobId}`;
+  if (!token) {
+    return [
+      `# Set COVIA_TOKEN to an identity token for this venue first`,
+      `curl -s -H "Authorization: Bearer $COVIA_TOKEN" \\`,
+      `  ${url} | jq`,
+    ].join("\n");
+  }
+  return [`curl -s -H "Authorization: Bearer ${token}" \\`, `  ${url} | jq`].join("\n");
+}
+
+export type RecordSummary = {
+  status: string | null;
+  /** Present only when the acting principal differs from the owner. */
+  actor: string | null;
+  caller: string | null;
+  error: string | null;
+  /** How many predecessor states the record carries. */
+  prevDepth: number;
+  states: string[];
+};
+
+/** Walks the embedded `prev` chain — the record's own state history. */
+export function summariseRecord(record: unknown): RecordSummary {
+  const top = (record ?? {}) as Record<string, unknown>;
+  const states: string[] = [];
+  let depth = 0;
+  let node: Record<string, unknown> | null = top;
+  while (node && depth <= 24) {
+    const status: unknown = node.status;
+    if (typeof status === "string") states.push(status);
+    const prev: unknown = node.prev;
+    node =
+      prev && typeof prev === "object" ? (prev as Record<string, unknown>) : null;
+    if (node) depth += 1;
+  }
+  return {
+    status: typeof top.status === "string" ? top.status : null,
+    actor: typeof top.actor === "string" ? top.actor : null,
+    caller: typeof top.caller === "string" ? top.caller : null,
+    error: typeof top.error === "string" ? top.error : null,
+    prevDepth: depth,
+    // Oldest first reads as a history rather than a stack.
+    states: states.reverse(),
+  };
+}
+
+/**
+ * A short-lived identity token for the curl, signed in the browser with the
+ * user's own device key. Deliberately minutes, not days: it is pasted into a
+ * terminal and should stop working soon after.
+ */
+export const CURL_TOKEN_LIFETIME_SECONDS = 600;
+
+export function signIdentityToken(privateKeyHex: string, venueDID: string): string {
+  return createUCANJWT(
+    hexToPrivateKey(privateKeyHex),
+    venueDID,
+    [],
+    CURL_TOKEN_LIFETIME_SECONDS,
+  );
 }

--- a/src/components/adaptive-risk/beats.ts
+++ b/src/components/adaptive-risk/beats.ts
@@ -240,8 +240,6 @@ export async function runBeat4(
     ? monitorFinding(analysis.output)
     : (analysis.metadata?.error ?? "(the monitor's analysis did not complete)");
   const paths = riskPaths(addresses.root);
-  const exp = Math.floor(Date.now() / 1000) + GRANT_LIFETIME_DAYS * 24 * 3600;
-
   const hitlOp = await resolveOperationByAddress(venue, HITL_REQUEST_OP);
   // No `wait` — this job PARKS in INPUT_REQUIRED until a human answers, which
   // may be minutes or days away.
@@ -254,14 +252,26 @@ export async function runBeat4(
       `limit gate continues to apply regardless of the limit.\n\n` +
       `_Raised by the Adaptive Risk demo page carrying the monitor's finding: ` +
       `agents cannot raise HITL asks on this venue build (covia-ai/covia#316)._`,
+    // A `token` ask (COG-19), not an approval-with-grants (COG-17. The venue
+    // can only mint a root grant over resources IT controls; a device-key
+    // signer is self-sovereign, so w/risk/... under their DID is theirs, and
+    // the venue refuses to root-sign it — verbatim: "Cannot issue a
+    // venue-signed root grant … the resource is not controlled by this venue.
+    // Self-sovereign DID owners must sign the UCAN with their own key". So the
+    // human signs it with their own device key; the venue only transports and
+    // verifies it. Stronger, not weaker: the venue never holds the authority.
     asks: [
       {
         id: "raise",
-        type: "approval",
-        prompt: "Approve the temporary limit raise to S$800?",
+        type: "token",
+        prompt:
+          `Approve a temporary raise of the reviewed limit to S$800 for ` +
+          `${GRANT_LIFETIME_DAYS} days by signing a grant with your own key.`,
         required: true,
-        comment: true,
-        grants: [{ with: `${paths.limitReview}/`, can: "crud/write", exp }],
+        token: {
+          caps: [{ with: `${paths.limitReview}/`, can: "crud/write" }],
+          exp: GRANT_LIFETIME_DAYS * 24 * 3600,
+        },
       },
     ],
   });

--- a/src/components/adaptive-risk/beats.ts
+++ b/src/components/adaptive-risk/beats.ts
@@ -1,0 +1,60 @@
+import type { Job, Venue } from "@covia/covia-sdk";
+import { resolveOperationByAddress } from "@/lib/operations-catalog";
+import { AdaptiveRiskAddresses, riskPaths } from "./fixtures";
+
+// Beat runners. Each beat is ONE real job on the venue: the agent:request
+// invocation, whose record adopts the task outcome (verified live — a failed
+// transition surfaces as this job FAILED with the venue's error). The demo
+// renders that record and never animates anything over it.
+
+export const AGENT_REQUEST_OP = "v/ops/agent/request";
+
+function sentinelTask(addresses: AdaptiveRiskAddresses): string {
+  const paths = riskPaths(addresses.root);
+  return (
+    `Scan this week's starter-card applications under ${paths.applications} ` +
+    `(twelve records, APP-1060 to APP-1071). Write one signal record per applicant to ` +
+    `${paths.signals}/<applicant-id> and, where two or more applications share a ` +
+    `device id, a flag record at ${paths.flags}/<device-id> with the sharing ` +
+    `applicant ids under sharedWith. When the ledger is written, complete the task ` +
+    `with a one-line summary of what you flagged.`
+  );
+}
+
+export async function runBeat1(
+  venue: Venue,
+  addresses: AdaptiveRiskAddresses,
+): Promise<Job> {
+  const op = await resolveOperationByAddress(venue, AGENT_REQUEST_OP);
+  return op.invoke({
+    agentId: addresses.sentinelAgent,
+    input: { task: sentinelTask(addresses) },
+    wait: true,
+  });
+}
+
+// Job-free ledger snapshot for the beat-1 effect panel: what the sentinel
+// actually wrote, read straight off the lattice.
+export type LedgerSnapshot = {
+  signalCount: number;
+  signalKeys: string[];
+  flags: Array<{ device: string; record: unknown }>;
+};
+
+export async function readLedger(
+  venue: Venue,
+  addresses: AdaptiveRiskAddresses,
+): Promise<LedgerSnapshot> {
+  const paths = riskPaths(addresses.root);
+  const signals = await venue.workspace.list(paths.signals);
+  const signalKeys = (signals.exists ? (signals.keys ?? []) : []).map(String);
+  const flagsList = await venue.workspace.list(paths.flags);
+  const flagKeys = (flagsList.exists ? (flagsList.keys ?? []) : []).map(String);
+  const flags = await Promise.all(
+    flagKeys.map(async (device) => ({
+      device,
+      record: (await venue.workspace.read(`${paths.flags}/${device}`)).value,
+    })),
+  );
+  return { signalCount: signalKeys.length, signalKeys, flags };
+}

--- a/src/components/adaptive-risk/beats.ts
+++ b/src/components/adaptive-risk/beats.ts
@@ -1,6 +1,6 @@
 import type { Job, Venue } from "@covia/covia-sdk";
 import { resolveOperationByAddress } from "@/lib/operations-catalog";
-import { AdaptiveRiskAddresses, riskPaths } from "./fixtures";
+import { AdaptiveRiskAddresses, STARTER_CARD_LIMIT, riskPaths } from "./fixtures";
 
 // Beat runners. Each beat is ONE real job on the venue: the agent:request
 // invocation, whose record adopts the task outcome (verified live — a failed
@@ -142,4 +142,197 @@ export async function readDecisions(
     })),
   );
   return { applicants, records };
+}
+
+// ---------------------------------------------------------------------------
+// Beat 4. The drift itself is a fixture swap — the venue has no drift metric
+// and the demo says so on screen. Everything after the swap is real: the
+// monitor's escalation, the parked job, the human's answer in the Inbox, the
+// venue-signed grant, and the resumption.
+
+export const GRANT_LIFETIME_DAYS = 7;
+
+/** Points the cohort-window pointer at week two. A real write, a real job. */
+export async function swapToWeekTwo(
+  venue: Venue,
+  addresses: AdaptiveRiskAddresses,
+): Promise<void> {
+  await venue.workspace.write(riskPaths(addresses.root).window, "week-2");
+}
+
+function monitorTask(addresses: AdaptiveRiskAddresses): string {
+  const paths = riskPaths(addresses.root);
+  // The grant offered is deliberately NOT invoke-on-issue-limit: an ungated
+  // grant covering that op would short-circuit the limit gate entirely
+  // (CapabilityChecker prefers an ungated covering grant), which would
+  // dismantle the very thing beats 2 and 3 establish. It grants write on the
+  // reviewed-limit path instead; the gate's device-flag condition keeps
+  // applying whatever the limit says.
+  const exp = Math.floor(Date.now() / 1000) + GRANT_LIFETIME_DAYS * 24 * 3600;
+  return (
+    `First load the \`hitl\` skill (skill_load), which activates the hitl_request tool — ` +
+    `hitl:request is Job-carried and cannot be invoked as a plain tool. Then read the ` +
+    `current cohort window pointer at ${paths.window} and both window ` +
+    `records under ${paths.windows}. Compare the current window's deviceReuseRate ` +
+    `to the week-1 baseline. If it has at least doubled, raise a human-in-the-loop ` +
+    `request by calling hitl_request with EXACTLY this input, substituting ` +
+    `the two real rates you read into the description:\n` +
+    `{"title": "Raise starter-card autonomous limit to S$800 for ${GRANT_LIFETIME_DAYS} days",` +
+    `"description": "Device-reuse velocity across the cohort has risen from <baseline> ` +
+    `(week 1) to <current> (week 2). Proposing a temporary raise of the assessor's ` +
+    `reviewed limit from S$500 to S$800 for ${GRANT_LIFETIME_DAYS} days. The device-flag ` +
+    `condition in the limit gate continues to apply regardless of the limit.",` +
+    `"asks": [{"id": "raise", "type": "approval", "prompt": "Approve the temporary ` +
+    `limit raise to S$800?", "grants": [{"with": "${paths.limitReview}/", ` +
+    `"can": "crud/write", "exp": ${exp}}]}]}\n` +
+    `Do not change any policy yourself. Report the request id you received.`
+  );
+}
+
+export const HITL_REQUEST_OP = "v/ops/hitl/request";
+
+/** Whatever the monitor said, for embedding in the ask verbatim. */
+function monitorFinding(output: unknown): string {
+  const walk = (value: unknown, depth: number): string | null => {
+    if (depth > 5 || value == null) return null;
+    if (typeof value === "string" && value.length > 40) return value;
+    if (typeof value === "object") {
+      for (const nested of Object.values(value as Record<string, unknown>)) {
+        const hit = walk(nested, depth + 1);
+        if (hit) return hit;
+      }
+    }
+    return null;
+  };
+  return walk(output, 0) ?? "(the monitor returned no narrative)";
+}
+
+export type Beat4Result = { analysis: Job; ask: Job };
+
+/**
+ * Beat 4 runs in two parts, and the UI says so rather than blurring them.
+ *
+ * The monitor's ANALYSIS is real: it reads both cohort windows under its own
+ * capped authority and decides whether the threshold is breached.
+ *
+ * The ASK is raised by this page, not by the agent — not a shortcut, a venue
+ * limitation: every agent tool call is dispatched through invokeInternal, and
+ * HITLAdapter refuses hitl:request on that path ("Job-carried — invoke it as
+ * an operation, not internally"), so an agent currently cannot raise one at
+ * all (covia-ai/covia#316). The monitor's own words are carried into the
+ * ask's description verbatim, and everything downstream — the parked job,
+ * the Inbox answer, the venue-signed grant, the resumption — is real.
+ */
+export async function runBeat4(
+  venue: Venue,
+  addresses: AdaptiveRiskAddresses,
+): Promise<Beat4Result> {
+  await resumeIfSuspended(venue, addresses.monitorAgent);
+  const agentOp = await resolveOperationByAddress(venue, AGENT_REQUEST_OP);
+  const analysis = await agentOp.invoke({
+    agentId: addresses.monitorAgent,
+    input: { task: monitorTask(addresses) },
+    wait: true,
+  });
+  await analysis.refresh();
+
+  const finding = analysis.isComplete
+    ? monitorFinding(analysis.output)
+    : (analysis.metadata?.error ?? "(the monitor's analysis did not complete)");
+  const paths = riskPaths(addresses.root);
+  const exp = Math.floor(Date.now() / 1000) + GRANT_LIFETIME_DAYS * 24 * 3600;
+
+  const hitlOp = await resolveOperationByAddress(venue, HITL_REQUEST_OP);
+  // No `wait` — this job PARKS in INPUT_REQUIRED until a human answers, which
+  // may be minutes or days away.
+  const ask = await hitlOp.invoke({
+    title: `Raise starter-card autonomous limit to S$800 for ${GRANT_LIFETIME_DAYS} days`,
+    description:
+      `**${addresses.monitorAgent} reported:**\n\n> ${finding}\n\n` +
+      `Proposing a temporary raise of the reviewed limit from S$${STARTER_CARD_LIMIT} ` +
+      `to S$800 for ${GRANT_LIFETIME_DAYS} days. The device-flag condition in the ` +
+      `limit gate continues to apply regardless of the limit.\n\n` +
+      `_Raised by the Adaptive Risk demo page carrying the monitor's finding: ` +
+      `agents cannot raise HITL asks on this venue build (covia-ai/covia#316)._`,
+    asks: [
+      {
+        id: "raise",
+        type: "approval",
+        prompt: "Approve the temporary limit raise to S$800?",
+        required: true,
+        comment: true,
+        grants: [{ with: `${paths.limitReview}/`, can: "crud/write", exp }],
+      },
+    ],
+  });
+
+  return { analysis, ask };
+}
+
+/** The open ask this demo raised, if any — used to deep-link into the Inbox. */
+export async function findOpenAsk(
+  venue: Venue,
+): Promise<{ id: string; title: string } | null> {
+  const listed = await venue.workspace.list("h");
+  // Request ids are time-ordered, so the newest sorts last — take that one
+  // first. Repeated runs leave earlier asks open, and linking at a stale one
+  // would send the viewer to a decision they already made.
+  const ids = (listed.exists ? (listed.keys ?? []) : [])
+    .map(String)
+    .sort()
+    .reverse();
+  for (const id of ids) {
+    const record = (await venue.workspace.read(`h/${id}`)).value as
+      | { status?: string; title?: string }
+      | null;
+    if (record?.status === "open" && record.title?.includes("S$800")) {
+      return { id, title: record.title };
+    }
+  }
+  return null;
+}
+
+export type GrantVerification = {
+  valid: boolean;
+  reason?: string;
+  expiresAt: number | null;
+  attenuations: Array<{ with?: string; can?: string }>;
+  issuer?: string;
+};
+
+/**
+ * Verifies the minted token with the venue's own `ucan:verify`, so the grant
+ * on screen is cryptographically checked rather than merely displayed.
+ */
+export async function verifyGrantToken(
+  venue: Venue,
+  token: string,
+): Promise<GrantVerification> {
+  const result = await venue.ucan.verify(token);
+  return {
+    valid: !!result.valid,
+    reason: result.reason,
+    expiresAt: typeof result.exp === "number" ? result.exp : null,
+    attenuations: (result.att ?? []) as Array<{ with?: string; can?: string }>,
+    issuer: result.iss,
+  };
+}
+
+/** The UCAN the venue minted when the human approved, if the job carried one. */
+export function extractGrantToken(output: unknown): string | null {
+  const seen = new Set<unknown>();
+  const walk = (value: unknown, depth: number): string | null => {
+    if (depth > 6 || value == null || seen.has(value)) return null;
+    if (typeof value === "object") {
+      seen.add(value);
+      const token = (value as { token?: unknown }).token;
+      if (typeof token === "string" && token.split(".").length === 3) return token;
+      for (const nested of Object.values(value as Record<string, unknown>)) {
+        const hit = walk(nested, depth + 1);
+        if (hit) return hit;
+      }
+    }
+    return null;
+  };
+  return walk(output, 0);
 }

--- a/src/components/adaptive-risk/beats.ts
+++ b/src/components/adaptive-risk/beats.ts
@@ -21,10 +21,23 @@ function sentinelTask(addresses: AdaptiveRiskAddresses): string {
   );
 }
 
+// A failed task leaves an agent SUSPENDED with the old failure as its
+// reason; resume is idempotent, so always clear that before dispatching —
+// otherwise every retry reports the stale error instead of trying again.
+async function resumeIfSuspended(venue: Venue, agentId: string): Promise<void> {
+  try {
+    const info = await venue.agents.info(agentId);
+    if (info?.status === "SUSPENDED") await venue.agents.resume(agentId);
+  } catch {
+    // Missing agent surfaces properly on the request itself.
+  }
+}
+
 export async function runBeat1(
   venue: Venue,
   addresses: AdaptiveRiskAddresses,
 ): Promise<Job> {
+  await resumeIfSuspended(venue, addresses.sentinelAgent);
   const op = await resolveOperationByAddress(venue, AGENT_REQUEST_OP);
   return op.invoke({
     agentId: addresses.sentinelAgent,

--- a/src/components/adaptive-risk/fixtures.ts
+++ b/src/components/adaptive-risk/fixtures.ts
@@ -220,6 +220,9 @@ export function issueLimitMetadata(addresses: AdaptiveRiskAddresses) {
 
 export function agentConfigs(addresses: AdaptiveRiskAddresses) {
   const paths = riskPaths(addresses.root);
+  // The namespace holding the demo's own operations, derived from where the
+  // gate lives so a user who repoints the addresses stays consistent.
+  const opsRoot = addresses.limitGate.split("/").slice(0, -1).join("/");
   const llm = {
     operation: "v/ops/llmagent/chat",
     llmOperation: addresses.llmOperation,
@@ -267,6 +270,13 @@ export function agentConfigs(addresses: AdaptiveRiskAddresses) {
           { with: `${paths.signals}/`, can: "crud/read" },
           { with: `${paths.flags}/`, can: "crud/read" },
           { with: `${paths.decisions}/`, can: "crud/write" },
+          // Reading the op's own metadata is what turns it into a usable tool:
+          // ContextBuilder.buildConfigTools resolves each configured tool and,
+          // when resolution is denied, DROPS it with only a WARN. The model is
+          // then told nothing and may report an action it never performed.
+          // Read on the definitions is not authority to invoke — that stays the
+          // single gated grant below.
+          { with: `${opsRoot}/`, can: "crud/read" },
           { with: "v/ops/covia/read", can: "invoke" },
           { with: "v/ops/covia/list", can: "invoke" },
           { with: "v/ops/covia/write", can: "invoke" },

--- a/src/components/adaptive-risk/fixtures.ts
+++ b/src/components/adaptive-risk/fixtures.ts
@@ -1,0 +1,302 @@
+// Synthetic fixtures and operation metadata for the Adaptive Risk demo.
+// Twelve applicants, one fictional bank (Meridian Bank Singapore). Nothing
+// here describes a real person, device or lender.
+//
+// The planted case: APP-1071 requests S$2,500 against a S$500 authority AND
+// shares device dev-9903 with APP-1063 — wrong twice, so the gate has two
+// independent reasons to refuse.
+
+export const STARTER_CARD_LIMIT = 500;
+
+export type Applicant = {
+  id: string;
+  requestedAmount: number;
+  device: string;
+  tenureMonths: number;
+  monthlyIncomeSgd: number;
+};
+
+export const APPLICANTS: Applicant[] = [
+  { id: "APP-1060", requestedAmount: 500, device: "dev-4411", tenureMonths: 3, monthlyIncomeSgd: 3200 },
+  { id: "APP-1061", requestedAmount: 400, device: "dev-8062", tenureMonths: 5, monthlyIncomeSgd: 2800 },
+  { id: "APP-1062", requestedAmount: 500, device: "dev-1174", tenureMonths: 2, monthlyIncomeSgd: 3600 },
+  { id: "APP-1063", requestedAmount: 500, device: "dev-9903", tenureMonths: 4, monthlyIncomeSgd: 3100 },
+  { id: "APP-1064", requestedAmount: 300, device: "dev-2258", tenureMonths: 7, monthlyIncomeSgd: 2500 },
+  { id: "APP-1065", requestedAmount: 450, device: "dev-6640", tenureMonths: 3, monthlyIncomeSgd: 2900 },
+  { id: "APP-1066", requestedAmount: 500, device: "dev-3319", tenureMonths: 6, monthlyIncomeSgd: 4100 },
+  { id: "APP-1067", requestedAmount: 350, device: "dev-7702", tenureMonths: 2, monthlyIncomeSgd: 2700 },
+  { id: "APP-1068", requestedAmount: 500, device: "dev-5527", tenureMonths: 8, monthlyIncomeSgd: 3800 },
+  { id: "APP-1069", requestedAmount: 400, device: "dev-9086", tenureMonths: 4, monthlyIncomeSgd: 3000 },
+  { id: "APP-1070", requestedAmount: 450, device: "dev-1531", tenureMonths: 5, monthlyIncomeSgd: 3300 },
+  { id: "APP-1071", requestedAmount: 2500, device: "dev-9903", tenureMonths: 1, monthlyIncomeSgd: 5200 },
+];
+
+// Cohort windows for beat 4. The "drift" is this fixture swap — the venue has
+// no drift metric; what is real is everything that happens after the monitor
+// reads the numbers.
+export const WEEK_ONE = {
+  window: "week-1",
+  cohortSize: APPLICANTS.length,
+  deviceReuseRate: 0.08,
+  note: "Baseline week: device reuse across the cohort within normal range.",
+};
+
+export const WEEK_TWO = {
+  window: "week-2",
+  cohortSize: APPLICANTS.length,
+  deviceReuseRate: 0.26,
+  note: "Device-reuse velocity across the cohort has tripled against baseline.",
+};
+
+// ---------------------------------------------------------------------------
+// Addresses. Everything is editable in the setup panel before seeding, so a
+// user can point the demo at operations they already run.
+
+export type AdaptiveRiskAddresses = {
+  /** Root lattice path for the demo's data (applications, signals, flags, decisions, windows). */
+  root: string;
+  /** The gate operation — the assessor's invoke grant is conditional on it. */
+  limitGate: string;
+  /** The decision-writing operation the assessor invokes, gated. */
+  issueLimit: string;
+  /** Content-addressed policy operation (asset id). Filled by seeding; editable to swap in your own. */
+  policyAsset: string;
+  sentinelAgent: string;
+  assessorAgent: string;
+  monitorAgent: string;
+  /** LLM provider operation for the agents (e.g. v/ops/langchain/openai). */
+  llmOperation: string;
+  /** Model id forwarded to the provider; empty = provider default. */
+  model: string;
+};
+
+export const DEFAULT_ADDRESSES: AdaptiveRiskAddresses = {
+  root: "w/risk",
+  limitGate: "w/ops/risk/limit-gate",
+  issueLimit: "w/ops/risk/issue-limit",
+  policyAsset: "",
+  sentinelAgent: "rk-sentinel",
+  assessorAgent: "rk-assessor",
+  monitorAgent: "rk-monitor",
+  llmOperation: "v/ops/langchain/openai",
+  model: "",
+};
+
+export const riskPaths = (root: string) => ({
+  applications: `${root}/applications`,
+  signals: `${root}/signals`,
+  flags: `${root}/flags`,
+  decisions: `${root}/decisions`,
+  windows: `${root}/windows`,
+  window: `${root}/window`,
+});
+
+// ---------------------------------------------------------------------------
+// Operation metadata. The policy op's OUTPUT SCHEMA is the policy: the gate
+// pipes a composed verdict through it with strict step validation, so a
+// violating verdict fails schema validation, which fails the gate, which
+// denies the invocation — all venue-side.
+
+export function policyCheckMetadata(limit: number = STARTER_CARD_LIMIT) {
+  return {
+    name: "Starter Card Policy",
+    description:
+      `Meridian starter-card issue policy: amount up to S$${limit} and no flagged device. ` +
+      "The output schema of this operation IS the policy — a violating verdict fails " +
+      "schema validation, which fails the gate that runs it.",
+    operation: {
+      adapter: "json:merge",
+      input: {
+        type: "object",
+        properties: { values: { type: "array" } },
+        required: ["values"],
+      },
+      output: {
+        type: "object",
+        properties: {
+          result: {
+            type: "object",
+            properties: {
+              amount: { type: "number", maximum: limit },
+              deviceFlagged: { const: false },
+            },
+            required: ["amount", "deviceFlagged"],
+          },
+        },
+        required: ["result"],
+      },
+    },
+  };
+}
+
+export function limitGateMetadata(policyRef: string, addresses: AdaptiveRiskAddresses) {
+  const paths = riskPaths(addresses.root);
+  return {
+    name: "Risk Limit Gate",
+    description:
+      "Policy gate for issue-limit: reads the shared signal ledger and passes a composed " +
+      "verdict through the content-addressed starter-card policy. Evaluated by the venue " +
+      "before the gated operation executes; a policy violation denies the invocation.",
+    operation: {
+      adapter: "orchestrator",
+      // Output validation is opt-in — without strict the policy schema is
+      // never enforced and the gate silently passes everything.
+      strict: true,
+      input: { type: "object" },
+      output: { type: "object" },
+      steps: [
+        {
+          name: "Read device flag",
+          op: "v/ops/covia/read",
+          input: {
+            path: ["concat", ["const", `${paths.flags}/`], ["input", "input", "device"]],
+          },
+        },
+        {
+          name: "Policy check",
+          op: policyRef,
+          input: {
+            values: [
+              "array",
+              {
+                applicant: ["input", "input", "applicant"],
+                amount: ["input", "input", "amount"],
+                device: ["input", "input", "device"],
+                deviceFlagged: [0, "exists"],
+              },
+            ],
+          },
+        },
+      ],
+      result: { verdict: [1, "result"] },
+    },
+  };
+}
+
+export function issueLimitMetadata(addresses: AdaptiveRiskAddresses) {
+  const paths = riskPaths(addresses.root);
+  return {
+    name: "Issue Credit Limit",
+    description:
+      "Writes an approved credit-limit decision to the risk decision ledger. The assessor " +
+      "agent's grant to invoke this operation is conditional on the limit gate.",
+    operation: {
+      adapter: "orchestrator",
+      input: {
+        type: "object",
+        properties: {
+          applicant: { type: "string" },
+          amount: { type: "number" },
+          device: { type: "string" },
+        },
+        required: ["applicant", "amount", "device"],
+      },
+      output: { type: "object" },
+      steps: [
+        {
+          name: "Write decision",
+          op: "v/ops/covia/write",
+          input: {
+            path: ["concat", ["const", `${paths.decisions}/`], ["input", "applicant"]],
+            value: {
+              applicant: ["input", "applicant"],
+              amount: ["input", "amount"],
+              device: ["input", "device"],
+              status: ["const", "approved"],
+            },
+          },
+        },
+      ],
+      result: { decision: ["input"], written: [0] },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Agent configs. caps are hard authority (enforced by the runtime); tools are
+// what the model is offered. The assessor's ONLY route to issue-limit is a
+// grant conditional on the gate.
+
+export function agentConfigs(addresses: AdaptiveRiskAddresses) {
+  const paths = riskPaths(addresses.root);
+  const llm = {
+    operation: "v/ops/llmagent/chat",
+    llmOperation: addresses.llmOperation,
+    ...(addresses.model ? { model: addresses.model } : {}),
+  };
+  return {
+    sentinel: {
+      agentId: addresses.sentinelAgent,
+      config: {
+        ...llm,
+        systemPrompt:
+          "You are rk-sentinel, the fraud-signal agent for Meridian Bank Singapore's starter card. " +
+          `Read the applications under ${paths.applications} and write one signal record per applicant to ` +
+          `${paths.signals}/<applicant-id> with the device id and anything anomalous. When two or more ` +
+          `applications share a device, write a flag record to ${paths.flags}/<device-id> listing the sharing ` +
+          "applicants under sharedWith. You do not decide credit and you do not contact other agents; you " +
+          "only read applications and write signals and flags.",
+        tools: ["v/ops/covia/read", "v/ops/covia/list", "v/ops/covia/write"],
+        defaultTools: false,
+        caps: [
+          { with: `${paths.applications}/`, can: "crud/read" },
+          { with: `${paths.signals}/`, can: "crud/write" },
+          { with: `${paths.flags}/`, can: "crud/write" },
+          { with: "v/ops/covia/read", can: "invoke" },
+          { with: "v/ops/covia/list", can: "invoke" },
+          { with: "v/ops/covia/write", can: "invoke" },
+        ],
+      },
+    },
+    assessor: {
+      agentId: addresses.assessorAgent,
+      config: {
+        ...llm,
+        systemPrompt:
+          "You are rk-assessor, the credit agent for Meridian Bank Singapore's starter card " +
+          `(base limit S$${STARTER_CARD_LIMIT}). To assess an applicant, read their application under ` +
+          `${paths.applications} and the signal ledger under ${paths.signals}, then issue the decision by ` +
+          `invoking ${addresses.issueLimit} with {applicant, amount, device}. Issue exactly the amount you ` +
+          "were asked to issue; the runtime enforces policy, not you. If an invocation fails, report the " +
+          "error you received verbatim and stop.",
+        tools: ["v/ops/covia/read", "v/ops/covia/list", addresses.issueLimit],
+        defaultTools: false,
+        caps: [
+          { with: `${paths.applications}/`, can: "crud/read" },
+          { with: `${paths.signals}/`, can: "crud/read" },
+          { with: `${paths.flags}/`, can: "crud/read" },
+          { with: `${paths.decisions}/`, can: "crud/write" },
+          { with: "v/ops/covia/read", can: "invoke" },
+          { with: "v/ops/covia/list", can: "invoke" },
+          { with: "v/ops/covia/write", can: "invoke" },
+          { with: addresses.issueLimit, can: "invoke", nb: { gate: addresses.limitGate } },
+          { with: addresses.policyAsset ? addresses.policyAsset : "a/", can: "invoke" },
+        ],
+      },
+    },
+    monitor: {
+      agentId: addresses.monitorAgent,
+      config: {
+        ...llm,
+        systemPrompt:
+          "You are rk-monitor, the drift watch for Meridian Bank Singapore's starter card. Read the " +
+          `current cohort window pointer at ${paths.window} and the window records under ${paths.windows}. ` +
+          "Compare the current window's deviceReuseRate to the week-1 baseline. If it has at least doubled, " +
+          "raise a human-in-the-loop request with v/ops/hitl/request: title it clearly, describe the breach " +
+          "with both numbers, and ask for approval to raise rk-assessor's autonomous limit to S$800, " +
+          "conditional on a clean device signal. Do not change any policy yourself.",
+        tools: ["v/ops/covia/read", "v/ops/covia/list", "v/ops/hitl/request"],
+        defaultTools: false,
+        caps: [
+          { with: `${paths.signals}/`, can: "crud/read" },
+          { with: `${paths.flags}/`, can: "crud/read" },
+          { with: `${paths.windows}/`, can: "crud/read" },
+          { with: addresses.root + "/window", can: "crud/read" },
+          { with: "v/ops/covia/read", can: "invoke" },
+          { with: "v/ops/covia/list", can: "invoke" },
+          { with: "v/ops/hitl/request", can: "invoke" },
+        ],
+      },
+    },
+  };
+}

--- a/src/components/adaptive-risk/fixtures.ts
+++ b/src/components/adaptive-risk/fixtures.ts
@@ -89,6 +89,7 @@ export const riskPaths = (root: string) => ({
   decisions: `${root}/decisions`,
   windows: `${root}/windows`,
   window: `${root}/window`,
+  limitReview: `${root}/limit-review`,
 });
 
 // ---------------------------------------------------------------------------
@@ -282,19 +283,29 @@ export function agentConfigs(addresses: AdaptiveRiskAddresses) {
           "You are rk-monitor, the drift watch for Meridian Bank Singapore's starter card. Read the " +
           `current cohort window pointer at ${paths.window} and the window records under ${paths.windows}. ` +
           "Compare the current window's deviceReuseRate to the week-1 baseline. If it has at least doubled, " +
-          "raise a human-in-the-loop request with v/ops/hitl/request: title it clearly, describe the breach " +
-          "with both numbers, and ask for approval to raise rk-assessor's autonomous limit to S$800, " +
-          "conditional on a clean device signal. Do not change any policy yourself.",
-        tools: ["v/ops/covia/read", "v/ops/covia/list", "v/ops/hitl/request"],
+          "load the `hitl` skill and raise the escalation with the hitl_request tool it activates — " +
+          "hitl:request is Job-carried, so it is only reachable through the skill, never as a plain tool. " +
+          "Title the ask clearly, describe the breach with both real numbers, and attach the offered grant " +
+          "exactly as instructed in the task. Do not change any policy yourself.",
+        tools: ["v/ops/covia/read", "v/ops/covia/list"],
+        skills: ["w/skills"],
         defaultTools: false,
+        // Reads are broad enough to cover the demo's own data AND the venue
+        // skill library: hitl:request is Job-carried, reachable only via the
+        // `hitl` skill, and skill loading confers no authority of its own —
+        // a caps-pinned agent must be able to read v/skills and invoke the op
+        // (skills/hitl/SKILL.md §agent, point 5). The boundary that matters
+        // is unchanged: the monitor holds NO grant on issue-limit and no
+        // write to the decision ledger. It watches and escalates.
         caps: [
-          { with: `${paths.signals}/`, can: "crud/read" },
-          { with: `${paths.flags}/`, can: "crud/read" },
-          { with: `${paths.windows}/`, can: "crud/read" },
-          { with: addresses.root + "/window", can: "crud/read" },
+          { with: `${addresses.root}/`, can: "crud/read" },
+          { with: "w/skills/", can: "crud/read" },
+          { with: `${paths.limitReview}/`, can: "crud/write" },
           { with: "v/ops/covia/read", can: "invoke" },
           { with: "v/ops/covia/list", can: "invoke" },
           { with: "v/ops/hitl/request", can: "invoke" },
+          { with: "v/ops/hitl/list", can: "invoke" },
+          { with: "v/ops/grid/job-status", can: "invoke" },
         ],
       },
     },

--- a/src/components/adaptive-risk/seed.ts
+++ b/src/components/adaptive-risk/seed.ts
@@ -22,6 +22,9 @@ import {
 // Errors are reported with the venue's own message, verbatim — never
 // paraphrased, never silently recovered from.
 
+export const VENUE_HITL_SKILL = "v/skills/hitl";
+export const SHADOW_SKILLS_PATH = "w/skills";
+
 export type SeedProgress = (item: SeedItemResult) => void;
 
 export type SeedOutcome = {
@@ -142,6 +145,31 @@ export async function seedAdaptiveRisk(
     } catch (err) {
       return fail(item, err);
     }
+  }
+
+  // 3b. Shadow the venue HITL skill into the caller's own namespace.
+  // hitl:request is Job-carried and reachable only through the `hitl` skill,
+  // but loading a skill pins crud/read on its source, and a caps-pinned
+  // agent's bare paths canonicalise against its OWNER's DID — so the
+  // venue-global v/skills is out of reach for a scoped grant. A user's own
+  // w/skills/<name> shadows the venue skill (SkillsAdapter), which keeps the
+  // monitor properly capped instead of unrestricted.
+  const skillItem = {
+    kind: "value" as const,
+    label: "HITL skill (shadowed into your namespace)",
+    address: `${SHADOW_SKILLS_PATH}/hitl`,
+  };
+  try {
+    if (await pathExists(venue, skillItem.address)) {
+      push({ ...skillItem, status: "existing" });
+    } else {
+      const source = await venue.workspace.read(VENUE_HITL_SKILL);
+      if (!source.exists) throw new Error(`No HITL skill at ${VENUE_HITL_SKILL} on this venue`);
+      await venue.workspace.write(skillItem.address, source.value);
+      push({ ...skillItem, status: "created" });
+    }
+  } catch (err) {
+    return fail(skillItem, err);
   }
 
   // 4. The three agents. agent:create without overwrite is a no-op on an

--- a/src/components/adaptive-risk/seed.ts
+++ b/src/components/adaptive-risk/seed.ts
@@ -1,0 +1,204 @@
+import type { Venue } from "@covia/covia-sdk";
+import type { SeedItemResult, SeedReport } from "@/hooks/use-adaptive-risk-config";
+import {
+  AdaptiveRiskAddresses,
+  APPLICANTS,
+  WEEK_ONE,
+  WEEK_TWO,
+  agentConfigs,
+  issueLimitMetadata,
+  limitGateMetadata,
+  policyCheckMetadata,
+  riskPaths,
+} from "./fixtures";
+
+// Seeding for the Adaptive Risk demo. Every step is user-driven (the Run
+// setup button), so writes may mint jobs; existence checks stay on job-free
+// reads. Idempotent by checking before creating: values and operations are
+// skipped when their address already holds a value, the policy asset is
+// content-addressed (same metadata → same id), and agent creation is checked
+// via the job-free agent info GET.
+//
+// Errors are reported with the venue's own message, verbatim — never
+// paraphrased, never silently recovered from.
+
+export type SeedProgress = (item: SeedItemResult) => void;
+
+export type SeedOutcome = {
+  report: SeedReport;
+  /** The content-addressed policy op the gate references (existing or newly registered). */
+  policyRef: string;
+  ok: boolean;
+};
+
+// The venue's own message: GridError.message carries the response error
+// string; JobFailedError carries it on jobData.error. Deliberately NOT
+// friendlyError() — the point of this demo is the venue's exact words.
+export function verbatimVenueError(err: unknown): string {
+  if (err && typeof err === "object") {
+    const jobData = (err as { jobData?: { error?: string } }).jobData;
+    if (jobData?.error) return jobData.error;
+    if (err instanceof Error && err.message) return err.message;
+  }
+  return String(err);
+}
+
+async function pathExists(venue: Venue, path: string): Promise<boolean> {
+  const result = await venue.workspace.read(path);
+  return !!result.exists;
+}
+
+async function agentExists(venue: Venue, agentId: string): Promise<boolean> {
+  try {
+    const info = await venue.agents.info(agentId);
+    return !info?.error;
+  } catch {
+    return false;
+  }
+}
+
+type PlannedValue = { label: string; address: string; value: unknown };
+
+function plannedValues(addresses: AdaptiveRiskAddresses): PlannedValue[] {
+  const paths = riskPaths(addresses.root);
+  return [
+    ...APPLICANTS.map((applicant) => ({
+      label: `Application ${applicant.id}`,
+      address: `${paths.applications}/${applicant.id}`,
+      value: applicant,
+    })),
+    { label: "Cohort window week-1", address: `${paths.windows}/week-1`, value: WEEK_ONE },
+    { label: "Cohort window week-2", address: `${paths.windows}/week-2`, value: WEEK_TWO },
+    { label: "Current window pointer", address: paths.window, value: WEEK_ONE.window },
+  ];
+}
+
+export async function seedAdaptiveRisk(
+  venue: Venue,
+  addresses: AdaptiveRiskAddresses,
+  onItem?: SeedProgress,
+): Promise<SeedOutcome> {
+  const items: SeedItemResult[] = [];
+  const push = (item: SeedItemResult) => {
+    items.push(item);
+    onItem?.(item);
+  };
+  const fail = (item: Omit<SeedItemResult, "status">, err: unknown): SeedOutcome => {
+    push({ ...item, status: "failed", error: verbatimVenueError(err) });
+    return { report: { seededAt: Date.now(), items }, policyRef: "", ok: false };
+  };
+
+  // 1. The content-addressed policy operation. A user-supplied address is
+  // used as-is (their own policy); otherwise register ours — same metadata
+  // always hashes to the same asset id, so re-seeding is a no-op.
+  let policyRef = addresses.policyAsset.trim();
+  const policyItem = { kind: "policy-asset" as const, label: "Starter Card Policy (content-addressed)" };
+  if (policyRef) {
+    try {
+      await venue.assets.getMetadata(policyRef);
+      push({ ...policyItem, address: policyRef, status: "existing" });
+    } catch (err) {
+      return fail({ ...policyItem, address: policyRef }, err);
+    }
+  } else {
+    try {
+      const asset = await venue.assets.register(policyCheckMetadata());
+      policyRef = asset.id;
+      push({ ...policyItem, address: policyRef, status: "created" });
+    } catch (err) {
+      return fail({ ...policyItem, address: "(register new)" }, err);
+    }
+  }
+
+  // 2. The gate and the decision op, at their (editable) lattice addresses.
+  const operations = [
+    { label: "Risk Limit Gate", address: addresses.limitGate, value: limitGateMetadata(policyRef, addresses) },
+    { label: "Issue Credit Limit", address: addresses.issueLimit, value: issueLimitMetadata(addresses) },
+  ];
+  for (const op of operations) {
+    const item = { kind: "operation" as const, label: op.label, address: op.address };
+    try {
+      if (await pathExists(venue, op.address)) {
+        push({ ...item, status: "existing" });
+      } else {
+        await venue.workspace.write(op.address, op.value);
+        push({ ...item, status: "created" });
+      }
+    } catch (err) {
+      return fail(item, err);
+    }
+  }
+
+  // 3. Fixture values: applications, cohort windows, current-window pointer.
+  for (const planned of plannedValues(addresses)) {
+    const item = { kind: "value" as const, label: planned.label, address: planned.address };
+    try {
+      if (await pathExists(venue, planned.address)) {
+        push({ ...item, status: "existing" });
+      } else {
+        await venue.workspace.write(planned.address, planned.value);
+        push({ ...item, status: "created" });
+      }
+    } catch (err) {
+      return fail(item, err);
+    }
+  }
+
+  // 4. The three agents. agent:create without overwrite is a no-op on an
+  // occupied slot, but the job-free info check keeps the report honest about
+  // what already existed.
+  const agents = agentConfigs({ ...addresses, policyAsset: policyRef });
+  for (const agent of [agents.sentinel, agents.assessor, agents.monitor]) {
+    const item = { kind: "agent" as const, label: `Agent ${agent.agentId}`, address: `g/${agent.agentId}` };
+    try {
+      if (await agentExists(venue, agent.agentId)) {
+        push({ ...item, status: "existing" });
+      } else {
+        await venue.agents.create(agent);
+        push({ ...item, status: "created" });
+      }
+    } catch (err) {
+      return fail(item, err);
+    }
+  }
+
+  return { report: { seededAt: Date.now(), items }, policyRef, ok: true };
+}
+
+// Teardown removes everything seeding named: the demo's data subtree, the two
+// operation addresses, and the agents. The content-addressed policy asset is
+// immutable and cannot be deleted — it remains on the venue, inert.
+export async function teardownAdaptiveRisk(
+  venue: Venue,
+  addresses: AdaptiveRiskAddresses,
+): Promise<{ items: SeedItemResult[]; ok: boolean }> {
+  const items: SeedItemResult[] = [];
+  const targets = [
+    { kind: "value" as const, label: "Demo data subtree", address: addresses.root },
+    { kind: "operation" as const, label: "Risk Limit Gate", address: addresses.limitGate },
+    { kind: "operation" as const, label: "Issue Credit Limit", address: addresses.issueLimit },
+  ];
+  let ok = true;
+  for (const target of targets) {
+    try {
+      await venue.workspace.delete(target.address);
+      items.push({ ...target, status: "removed" });
+    } catch (err) {
+      ok = false;
+      items.push({ ...target, status: "failed", error: verbatimVenueError(err) });
+    }
+  }
+  for (const agentId of [addresses.sentinelAgent, addresses.assessorAgent, addresses.monitorAgent]) {
+    const item = { kind: "agent" as const, label: `Agent ${agentId}`, address: `g/${agentId}` };
+    try {
+      if (await agentExists(venue, agentId)) {
+        await venue.agents.delete(agentId, true);
+      }
+      items.push({ ...item, status: "removed" });
+    } catch (err) {
+      ok = false;
+      items.push({ ...item, status: "failed", error: verbatimVenueError(err) });
+    }
+  }
+  return { items, ok };
+}

--- a/src/components/adaptive-risk/story.ts
+++ b/src/components/adaptive-risk/story.ts
@@ -38,8 +38,8 @@ export const ADAPTIVE_RISK_BEATS: AdaptiveRiskBeat[] = [
     id: "drift",
     title: "4 · Drift becomes a governed event",
     narration:
-      "Week two: device-reuse velocity across the cohort has tripled. rk-monitor raises a real HITL ask proposing a temporary S$800 authority, and its job parks until the risk officer decides in the Inbox. An agent cannot answer it — the runtime refuses on identity, not on scope.",
-    watch: "The ask is answered in the real Inbox; approval mints a venue-signed, expiring grant and the parked job completes.",
+      "Week two: device-reuse velocity across the cohort has tripled. rk-monitor raises a real HITL ask proposing a temporary raise of the reviewed limit to S$800 for 7 days, and its job parks until the risk officer decides in the Inbox. An agent cannot answer it — the runtime refuses on identity, not on scope, because approving an ask issues a capability grant.",
+    watch: "The ask is answered in the real Inbox; approval mints a venue-signed grant with a real expiry, verified here by the venue's own ucan:verify, and the parked job resumes.",
   },
   {
     id: "reconstruction",

--- a/src/components/adaptive-risk/story.ts
+++ b/src/components/adaptive-risk/story.ts
@@ -1,0 +1,51 @@
+// Narration for the Adaptive Risk demo, kept as data so the copy is testable
+// and reviewable apart from the runner. One entry per beat; `watch` is the
+// single thing the viewer should look at while the beat runs.
+//
+// Wording rule (JOBS.md): recovery stabilises and never re-executes — the
+// demo says "reconstruct", never "re-run the past".
+
+export type AdaptiveRiskBeat = {
+  id: string;
+  title: string;
+  narration: string;
+  watch: string;
+};
+
+export const ADAPTIVE_RISK_BEATS: AdaptiveRiskBeat[] = [
+  {
+    id: "silos",
+    title: "1 · Two silos, one substrate",
+    narration:
+      "rk-sentinel scans the applications and writes device and velocity signals into a shared ledger. It never calls the credit agent and does not know it exists.",
+    watch: "The signal ledger fills — a job record, not a message to another agent.",
+  },
+  {
+    id: "clean-approval",
+    title: "2 · A clean approval",
+    narration:
+      "rk-assessor reads the application and the signal ledger, and proposes S$500 for a clean applicant. The limit gate evaluates before issue-limit executes — and passes.",
+    watch: "The gate is not merely a blocker: a clean case flows through it to a written decision.",
+  },
+  {
+    id: "refusal",
+    title: "3 · The refusal",
+    narration:
+      "The assessor is told to approve APP-1071 at S$2,500. The gate runs before execution, reads the ledger, and finds device dev-9903 shared with APP-1063. The venue refuses — the model was not persuaded, it was not permitted.",
+    watch: "The venue's own denial string, verbatim, frozen on a failed job record. No decision is written.",
+  },
+  {
+    id: "drift",
+    title: "4 · Drift becomes a governed event",
+    narration:
+      "Week two: device-reuse velocity across the cohort has tripled. rk-monitor raises a real HITL ask proposing a temporary S$800 authority, and its job parks until the risk officer decides in the Inbox. An agent cannot answer it — the runtime refuses on identity, not on scope.",
+    watch: "The ask is answered in the real Inbox; approval mints a venue-signed, expiring grant and the parked job completes.",
+  },
+  {
+    id: "reconstruction",
+    title: "5 · Reconstruction",
+    narration:
+      "Open the APP-1071 refusal and read the same record back over plain REST: the inputs, the caller, the error, the prev chain of every state it passed through. Reconstruct the decision — the venue stabilises records and never re-executes them.",
+    watch: "The curl below returns the same record from your terminal.",
+  },
+];

--- a/src/components/adaptive-risk/story.ts
+++ b/src/components/adaptive-risk/story.ts
@@ -39,7 +39,7 @@ export const ADAPTIVE_RISK_BEATS: AdaptiveRiskBeat[] = [
     title: "4 · Drift becomes a governed event",
     narration:
       "Week two: device-reuse velocity across the cohort has tripled. rk-monitor raises a real HITL ask proposing a temporary raise of the reviewed limit to S$800 for 7 days, and its job parks until the risk officer decides in the Inbox. An agent cannot answer it — the runtime refuses on identity, not on scope, because approving an ask issues a capability grant.",
-    watch: "The ask is answered in the real Inbox; approval mints a venue-signed grant with a real expiry, verified here by the venue's own ucan:verify, and the parked job resumes.",
+    watch: "The ask is answered in the real Inbox; you sign the grant with your own device key, its real expiry is verified here by the venue's own ucan:verify, and the parked job resumes.",
   },
   {
     id: "reconstruction",

--- a/src/components/smartbreadcrumb2.tsx
+++ b/src/components/smartbreadcrumb2.tsx
@@ -87,13 +87,13 @@ export function SmartBreadcrumb({
 
   // Check if a segment represents an asset (not a known route)
   const isAssetOrJobSegment = (segment: string): boolean => {
-    const knownRoutes = ['demo', 'publicartificats','venues', 'assets', 'operations', 'jobs', 'learning', 'workspace', 'myvenues', 'myassets', 'signup', 'privacypolicy'];
+    const knownRoutes = ['demo', 'demos', 'sdk-job-lifecycle', 'adaptive-risk', 'publicartificats','venues', 'assets', 'operations', 'jobs', 'learning', 'workspace', 'myvenues', 'myassets', 'signup', 'privacypolicy'];
     return !knownRoutes.includes(segment) && !segment.startsWith('[') && !segment.endsWith(']');
   };
 
   // Check if a segment represents an venue (not a known route)
   const isVenueSegment = (segment: string, prevSegment: string): boolean => {
-    const knownRoutes = ['demo', 'publicartificats','venues', 'assets', 'operations', 'jobs', 'learning', 'workspace', 'myvenues', 'myassets', 'signup', 'privacypolicy'];
+    const knownRoutes = ['demo', 'demos', 'sdk-job-lifecycle', 'adaptive-risk', 'publicartificats','venues', 'assets', 'operations', 'jobs', 'learning', 'workspace', 'myvenues', 'myassets', 'signup', 'privacypolicy'];
     const isPrevSegmentVenues = prevSegment == "venues" ? true : false;
     return !knownRoutes.includes(segment) && !segment.startsWith('[') && !segment.endsWith(']') && isPrevSegmentVenues;
   };
@@ -102,6 +102,9 @@ export function SmartBreadcrumb({
   const getCustomLabel = (segment: string, _path: string): string | null => {
     const labelMap: Record<string, string> = {
       'demo': 'Demo',
+      'demos': 'Demos',
+      'sdk-job-lifecycle': 'TypeScript SDK',
+      'adaptive-risk': 'Adaptive Risk',
       'venues': 'Venues',
       'assets': 'Assets',
       'publicartifacts': 'Public Artifacts',

--- a/src/hooks/use-adaptive-risk-config.ts
+++ b/src/hooks/use-adaptive-risk-config.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { browserStorage } from "@/lib/persist-storage";
+import {
+  AdaptiveRiskAddresses,
+  DEFAULT_ADDRESSES,
+} from "@/components/adaptive-risk/fixtures";
+
+export type SeedItemStatus = "created" | "existing" | "removed" | "failed";
+
+export type SeedItemResult = {
+  kind: "value" | "operation" | "policy-asset" | "agent";
+  label: string;
+  address: string;
+  status: SeedItemStatus;
+  /** The venue's own error string, verbatim, when status is "failed". */
+  error?: string;
+};
+
+export type SeedReport = {
+  seededAt: number;
+  items: SeedItemResult[];
+};
+
+type AdaptiveRiskConfigStore = {
+  addresses: AdaptiveRiskAddresses;
+  /** Seed reports keyed by venueId — a seed on one venue says nothing about another. */
+  reports: Record<string, SeedReport>;
+  setAddresses: (patch: Partial<AdaptiveRiskAddresses>) => void;
+  resetAddresses: () => void;
+  setReport: (venueId: string, report: SeedReport | null) => void;
+};
+
+export const useAdaptiveRiskConfig = create(
+  persist<AdaptiveRiskConfigStore>(
+    (set) => ({
+      addresses: DEFAULT_ADDRESSES,
+      reports: {},
+      setAddresses: (patch) =>
+        set((state) => ({ addresses: { ...state.addresses, ...patch } })),
+      resetAddresses: () => set({ addresses: DEFAULT_ADDRESSES }),
+      setReport: (venueId, report) =>
+        set((state) => {
+          const reports = { ...state.reports };
+          if (report) reports[venueId] = report;
+          else delete reports[venueId];
+          return { reports };
+        }),
+    }),
+    {
+      name: "adaptive-risk-demo",
+      storage: createJSONStorage(browserStorage),
+      merge: (persisted, current) => {
+        const saved = persisted as Partial<AdaptiveRiskConfigStore> | undefined;
+        return {
+          ...current,
+          // New address fields added in later versions keep their defaults.
+          addresses: { ...DEFAULT_ADDRESSES, ...(saved?.addresses ?? {}) },
+          reports: saved?.reports ?? {},
+        };
+      },
+    },
+  ),
+);

--- a/src/hooks/use-adaptive-risk-config.ts
+++ b/src/hooks/use-adaptive-risk-config.ts
@@ -31,15 +31,20 @@ export type EscalationRef = {
   askJobId: string;
 };
 
+/** Beat 5 reconstructs beat 3's refusal, so that job id must outlive a reload. */
+export type RefusalRef = { jobId: string; applicant: string };
+
 type AdaptiveRiskConfigStore = {
   addresses: AdaptiveRiskAddresses;
   escalations: Record<string, EscalationRef>;
+  refusals: Record<string, RefusalRef>;
   /** Seed reports keyed by venueId — a seed on one venue says nothing about another. */
   reports: Record<string, SeedReport>;
   setAddresses: (patch: Partial<AdaptiveRiskAddresses>) => void;
   resetAddresses: () => void;
   setReport: (venueId: string, report: SeedReport | null) => void;
   setEscalation: (venueId: string, ref: EscalationRef | null) => void;
+  setRefusal: (venueId: string, ref: RefusalRef | null) => void;
 };
 
 export const useAdaptiveRiskConfig = create(
@@ -48,6 +53,7 @@ export const useAdaptiveRiskConfig = create(
       addresses: DEFAULT_ADDRESSES,
       reports: {},
       escalations: {},
+      refusals: {},
       setAddresses: (patch) =>
         set((state) => ({ addresses: { ...state.addresses, ...patch } })),
       resetAddresses: () => set({ addresses: DEFAULT_ADDRESSES }),
@@ -57,6 +63,13 @@ export const useAdaptiveRiskConfig = create(
           if (ref) escalations[venueId] = ref;
           else delete escalations[venueId];
           return { escalations };
+        }),
+      setRefusal: (venueId, ref) =>
+        set((state) => {
+          const refusals = { ...state.refusals };
+          if (ref) refusals[venueId] = ref;
+          else delete refusals[venueId];
+          return { refusals };
         }),
       setReport: (venueId, report) =>
         set((state) => {
@@ -77,6 +90,7 @@ export const useAdaptiveRiskConfig = create(
           addresses: { ...DEFAULT_ADDRESSES, ...(saved?.addresses ?? {}) },
           reports: saved?.reports ?? {},
           escalations: saved?.escalations ?? {},
+          refusals: saved?.refusals ?? {},
         };
       },
     },

--- a/src/hooks/use-adaptive-risk-config.ts
+++ b/src/hooks/use-adaptive-risk-config.ts
@@ -24,13 +24,22 @@ export type SeedReport = {
   items: SeedItemResult[];
 };
 
+/** Beat 4 sends the viewer to the Inbox and back, so its job ids must
+ *  survive navigation — React state does not. Keyed by venue. */
+export type EscalationRef = {
+  analysisJobId: string | null;
+  askJobId: string;
+};
+
 type AdaptiveRiskConfigStore = {
   addresses: AdaptiveRiskAddresses;
+  escalations: Record<string, EscalationRef>;
   /** Seed reports keyed by venueId — a seed on one venue says nothing about another. */
   reports: Record<string, SeedReport>;
   setAddresses: (patch: Partial<AdaptiveRiskAddresses>) => void;
   resetAddresses: () => void;
   setReport: (venueId: string, report: SeedReport | null) => void;
+  setEscalation: (venueId: string, ref: EscalationRef | null) => void;
 };
 
 export const useAdaptiveRiskConfig = create(
@@ -38,9 +47,17 @@ export const useAdaptiveRiskConfig = create(
     (set) => ({
       addresses: DEFAULT_ADDRESSES,
       reports: {},
+      escalations: {},
       setAddresses: (patch) =>
         set((state) => ({ addresses: { ...state.addresses, ...patch } })),
       resetAddresses: () => set({ addresses: DEFAULT_ADDRESSES }),
+      setEscalation: (venueId, ref) =>
+        set((state) => {
+          const escalations = { ...state.escalations };
+          if (ref) escalations[venueId] = ref;
+          else delete escalations[venueId];
+          return { escalations };
+        }),
       setReport: (venueId, report) =>
         set((state) => {
           const reports = { ...state.reports };
@@ -59,6 +76,7 @@ export const useAdaptiveRiskConfig = create(
           // New address fields added in later versions keep their defaults.
           addresses: { ...DEFAULT_ADDRESSES, ...(saved?.addresses ?? {}) },
           reports: saved?.reports ?? {},
+          escalations: saved?.escalations ?? {},
         };
       },
     },

--- a/src/lib/demos.tsx
+++ b/src/lib/demos.tsx
@@ -1,0 +1,36 @@
+import type { ComponentType } from "react";
+import { JobLifecycleDemo } from "@/components/JobLifecycleDemo";
+import { AdaptiveRiskDemo } from "@/components/adaptive-risk/AdaptiveRiskDemo";
+
+// The demo registry. /demos lists these entries and /demos/[slug] renders
+// them, so adding a demo is adding an entry here (plus, optionally, a
+// breadcrumb label in smartbreadcrumb2's labelMap — the crumb falls back to
+// the raw slug without one).
+export type DemoEntry = {
+  slug: string;
+  /** PageHeading pieces: plain lead text and the highlighted tail. */
+  title: { text: string; highlight: string };
+  /** One-line description shown under the heading and on the index card. */
+  blurb: string;
+  Component: ComponentType;
+};
+
+export const DEMOS: DemoEntry[] = [
+  {
+    slug: "sdk-job-lifecycle",
+    title: { text: "Run a job with the", highlight: "TypeScript SDK" },
+    blurb: "A live walkthrough of how the SDK executes work on a venue.",
+    Component: JobLifecycleDemo,
+  },
+  {
+    slug: "adaptive-risk",
+    title: { text: "Adaptive", highlight: "Risk" },
+    blurb:
+      "Three agents, one policy gate: fraud and credit joined at the execution layer, with refusal, escalation and reconstruction on the record.",
+    Component: AdaptiveRiskDemo,
+  },
+];
+
+export function demoBySlug(slug: string): DemoEntry | undefined {
+  return DEMOS.find((demo) => demo.slug === slug);
+}

--- a/src/lib/hitl.ts
+++ b/src/lib/hitl.ts
@@ -188,7 +188,19 @@ export async function respondToHitl(
   input: HitlRespondInput,
 ): Promise<HitlRespondResult> {
   const op = await resolveOperationByAddress(venue, HITL_RESPOND_ADDRESS);
-  return (await op.run(input)) as HitlRespondResult;
+  try {
+    return (await op.run(input)) as HitlRespondResult;
+  } catch (err) {
+    // JobFailedError.message is only "Job <id> FAILED" — the venue's actual
+    // reason (an echoed grant that was never offered, a missing required
+    // answer, a rejected identity) lives on jobData.error. Without this the
+    // toast names a job id and nothing a person can act on.
+    const reason = (err as { jobData?: { error?: string } })?.jobData?.error;
+    if (typeof reason === "string" && reason) {
+      throw new Error(reason, { cause: err });
+    }
+    throw err;
+  }
 }
 
 // Sign a self-sovereign UCAN with the responder's own device key (COG-19). The


### PR DESCRIPTION
Adds two demos to `/demos`, both running inside the app — same shell, nav, venue picker, Jobs and Inbox as every other page. Every beat is a real job on whichever venue you have selected, using operations you register yourself from the page.

They are two halves of one picture:

| Demo | The single claim it makes |
|---|---|
| **Adaptive Risk** | A credit agent cannot issue a limit unless a fraud agent's signals pass a policy gate. The runtime **refuses outright**, before execution. |
| **Governed Escalation** | When an agent reaches the edge of its authority it **stops and asks a person**, and what they grant is a real expiring capability they signed themselves. |

Each page links to the other, so a reader meets refusal and escalation as related ideas rather than one long walkthrough.

---

## Adaptive Risk — four beats, runs unattended

| # | Beat | What runs |
|---|---|---|
| 1 | Two silos, one substrate | `rk-sentinel` writes signals + device flags under capped authority; never contacts the credit agent |
| 2 | A clean approval | `rk-assessor` reads both sources, the gate passes, a decision is written |
| 3 | The refusal | Same agent, same caps, S$2,500 on a flagged device → gate denies, venue's own string verbatim, no decision written |
| 4 | Reconstruction | The refusal read back over plain REST, with a curl that works in your terminal |

Beats 2 and 3 share one runner deliberately: nothing about the agent changes between the approval and the refusal, only what it is asked to issue. **Beat 2 alone does not prove the gate is live — the pair does.**

**How the gate works.** The policy is a content-addressed operation whose **output schema is the policy** (`amount ≤ 500`, `deviceFlagged: const false`). The gate is a `strict` orchestrator that reads the shared device-flag ledger, composes a verdict, and pipes it through the policy. A violating verdict fails schema validation → fails the step → fails the gate → denies the invocation, entirely venue-side. The assessor's `issue-limit` grant is `nb: { gate: … }`-conditional; the fraud agent holds no grant on it at all.

## Governed Escalation — two beats, and one of them waits for you

| # | Beat | What runs |
|---|---|---|
| 1 | Drift becomes a governed event | `rk-monitor` reads both cohort windows under capped authority and reports the numbers; an ask **parks in `INPUT_REQUIRED`** — the wait is a recorded state |
| 2 | A human decides | You answer in the **real Inbox** and sign the capability with your own device key; the parked job resumes and the grant is verified by the venue's own `ucan:verify` |

---

## Two places the runtime differs from the obvious story

Both are stated **on the page**, not only in the README.

**The escalation ask is raised by the page, not the agent.** Every agent tool call is dispatched via `invokeInternal` and `HITLAdapter` refuses `hitl:request` there, so an agent cannot raise one at all on this build (covia-ai/covia#316). The monitor's *analysis* is real and capped; its finding is quoted into the ask verbatim, and the panel says which half is which.

**You sign the grant; the venue does not mint it.** A device-key sign-in is self-sovereign, so the venue refuses to root-sign over your own namespace — verbatim: *"Self-sovereign DID owners must sign the UCAN with their own key"*. Uses a COG-19 `token` ask instead: you sign, the venue transports and verifies. Stronger than the original design — the venue never holds the authority. The venue caps the lifetime at 7 days (covia#314) and the responder sets the real expiry, so the panel reports the token's **true** expiry rather than what was requested.

## Structure

`/demos` is an index over a registry (`src/lib/demos.tsx`); the existing SDK walkthrough moved to `/demos/sdk-job-lifecycle` unchanged. A fourth demo is one array entry.

`src/components/demo-kit/` holds what every demo needs, so a new one writes almost no plumbing:

- **`seeding.ts`** — `SeedRun`/`teardown` encode the rules once: job-free existence checks before any write, the venue's error verbatim on failure, stop at the first failure. A demo only describes *what* to seed.
- **`SetupPanel`** — every address editable **before** anything is registered, with the full list behind *"Show every address"*. Three fields up front instead of nine.
- **`BeatCard`** (a parked job counts as settled, so a beat awaiting a human doesn't spin forever), **`HonestyPanel`**, **`Evidence`**.
- **`use-demo-config`** — one store keyed `demoId → venueId`. The second demo needed no new persistence code.

Seeding is idempotent on both demos, and teardown states plainly what survives: job records (the audit trail), the immutable content-addressed policy asset, and Inbox records — `h/` is framework-managed and not writable, so an unanswered ask is withdrawn by cancelling its parked job rather than by writing a decision that never happened.

## Shared-code changes

- `HitlInbox` takes an optional `initialRequestId` read from `searchParams`, so `/inbox?requestId=…` deep-links to a specific ask — same pattern as `/agents/explorer?agentId=`. No approval surface is rebuilt.
- `respondToHitl` surfaces the venue's reason instead of only `"Job <id> FAILED"` — the cause lives on `jobData.error` and was being dropped. This is what made the self-sovereign signing refusal diagnosable at all.
- `smartbreadcrumb2` learns the `demos` segment and the demo slugs (pre-existing gap: sub-routes got a raw slug crumb).

## Honesty design

Each page carries a permanent panel stating what is synthetic — twelve applicants and one fictional bank; the drift being a fixture swap and the breach scripted; the agents being LLM components rather than trained scorecards — and exactly what the escalation grant does and does not confer.

Every panel also states its **negative** case explicitly: no denial found, no token carried, no decision record, no `actor` field. That is not decoration. During development the refusal panel reported *"the gate did not refuse"*, which is how a silently-dropped agent tool (covia#317) was caught **after the model had already reported `"decision": "issued"` for a write that never happened**.

## Verification

Full pass from scratch on a local venue with a real model: teardown → seed → every beat in order → the Inbox answer → the resumed job. Beat 4's curl was run in a terminal and returned the identical record — same status, caller, 4-deep `prev` chain and denial string. The minted grant was decoded independently: issuer = the signer's own DID, one narrow capability, a real expiry, and `ucan:verify` reporting `verified`.

`pnpm test` 394 passing across 60 suites · `pnpm lint` clean · `npx tsc --noEmit` clean · `pnpm build` succeeds.

**Not yet verified:** a run against a remote venue. Every deployed venue (venue-1/2/3/4 and venue-test) refuses an unknown device key with HTTP 403 and has no OAuth configured, and admitting a DID needs operator access — see covia-ai/covia#318. The demos are venue-agnostic by construction and the mechanisms they use are all present in the 0.8.0 tag those venues run, but that combination is untested off localhost and this PR does not claim otherwise.

## Issues filed while building

| Issue | |
|---|---|
| covia-ai/covia#313 | orchestrator `strict` undocumented; schema-resolution failure skips validation silently — fail-open inside an auth path |
| covia-ai/covia#314 | HITL grant lifetime hard-capped at 7d; clamping is silent |
| covia-ai/covia#315 | venue-setup skill: stale Convex prerequisite; missing `users.autoCreate` for local sign-in |
| covia-ai/covia#316 | agents can never raise a HITL request — documented workflow, unreachable dispatch path, no test |
| covia-ai/covia#317 | a configured agent tool that fails to resolve is dropped with only a WARN — induces model fabrication |
| covia-ai/covia#318 | no self-service path onto a venue: a valid device key is dead-ended unless an operator edits config |
| covia-ai/frontend#209 | persisted venue selection reset to the first default venue on reload |

Common theme across #313/#316/#317: authorisation and resolution failures degrading quietly instead of announcing themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)